### PR TITLE
Pass watched Custom Resource to values mapper

### DIFF
--- a/pkg/client/actionclient.go
+++ b/pkg/client/actionclient.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+
 	sdkhandler "github.com/operator-framework/operator-lib/handler"
 	"gomodules.xyz/jsonpatch/v2"
 	"helm.sh/helm/v3/pkg/action"

--- a/pkg/client/actionclient.go
+++ b/pkg/client/actionclient.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-
 	sdkhandler "github.com/operator-framework/operator-lib/handler"
 	"gomodules.xyz/jsonpatch/v2"
 	"helm.sh/helm/v3/pkg/action"

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -529,7 +529,7 @@ func (r *Reconciler) getValues(obj *unstructured.Unstructured) (chartutil.Values
 	if err := crVals.ApplyOverrides(r.overrideValues); err != nil {
 		return chartutil.Values{}, err
 	}
-	vals := r.valueMapper.Map(crVals.Map())
+	vals := r.valueMapper.Map(obj, crVals.Map())
 	vals, err = chartutil.CoalesceValues(r.chrt, vals)
 	if err != nil {
 		return chartutil.Values{}, err

--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -18,14 +18,17 @@ package values
 
 import (
 	"helm.sh/helm/v3/pkg/chartutil"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 type Mapper interface {
-	Map(chartutil.Values) chartutil.Values
+	Map(*unstructured.Unstructured, chartutil.Values) chartutil.Values
 }
 
-type MapperFunc func(chartutil.Values) chartutil.Values
+// MapperFunc takes the original values and the watched custom resource to modify its contents, i.e. to map a custom
+// resource or set new values based on cluster state.
+type MapperFunc func(*unstructured.Unstructured, chartutil.Values) chartutil.Values
 
-func (m MapperFunc) Map(v chartutil.Values) chartutil.Values {
-	return m(v)
+func (m MapperFunc) Map(cr *unstructured.Unstructured, v chartutil.Values) chartutil.Values {
+	return m(cr, v)
 }


### PR DESCRIPTION
To map values from Custom Resources it is necessary to have access to the current reconciled CR inside the values mapper. 