### PR TITLE
Update hybrid plugin scaffolding

### DIFF
--- a/pkg/plugins/hybrid/v1alpha/scaffolds/init.go
+++ b/pkg/plugins/hybrid/v1alpha/scaffolds/init.go
@@ -110,7 +110,9 @@ func (s *initScaffolder) Scaffold() error {
 		machinery.WithBoilerplate(string(boilerplate)),
 	)
 
-	if err := os.MkdirAll(chartutil.HelmChartsDir, 0755); err != nil {
+	// create placeholder directories for helm charts and go apis
+	err = createDirectories([]string{chartutil.HelmChartsDir, "api", "controllers"})
+	if err != nil {
 		return err
 	}
 
@@ -131,9 +133,6 @@ func (s *initScaffolder) Scaffold() error {
 		&templates.DockerIgnore{},
 	)
 
-	// Add note to include any depedencies in dockerfile which are required to build `main.go`.
-	fmt.Println("Include any dependencies required to build `main.go` in your project to Dockerfile")
-
 	if err != nil {
 		return err
 	}
@@ -144,5 +143,14 @@ func (s *initScaffolder) Scaffold() error {
 		return err
 	}
 
+	return nil
+}
+
+func createDirectories(directories []string) error {
+	for _, dir := range directories {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("unable to create directory %q : %v", dir, err)
+		}
+	}
 	return nil
 }

--- a/pkg/plugins/hybrid/v1alpha/scaffolds/init.go
+++ b/pkg/plugins/hybrid/v1alpha/scaffolds/init.go
@@ -19,10 +19,12 @@ package scaffolds
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/operator-framework/helm-operator-plugins/pkg/plugins/hybrid/v1alpha/scaffolds/internal/templates"
 	"github.com/operator-framework/helm-operator-plugins/pkg/plugins/hybrid/v1alpha/scaffolds/internal/templates/hack"
 	"github.com/operator-framework/helm-operator-plugins/pkg/plugins/hybrid/v1alpha/scaffolds/internal/templates/rbac"
+	"github.com/operator-framework/helm-operator-plugins/pkg/plugins/v1/chartutil"
 	"github.com/spf13/afero"
 	"sigs.k8s.io/kubebuilder/v3/pkg/config"
 	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
@@ -108,6 +110,10 @@ func (s *initScaffolder) Scaffold() error {
 		machinery.WithBoilerplate(string(boilerplate)),
 	)
 
+	if err := os.MkdirAll(chartutil.HelmChartsDir, 0755); err != nil {
+		return err
+	}
+
 	err = scaffold.Execute(
 		&templates.Main{},
 		&templates.GoMod{ControllerRuntimeVersion: ControllerRuntimeVersion},
@@ -124,6 +130,9 @@ func (s *initScaffolder) Scaffold() error {
 		&templates.Dockerfile{},
 		&templates.DockerIgnore{},
 	)
+
+	// Add note to include any depedencies in dockerfile which are required to build `main.go`.
+	fmt.Println("Include any dependencies required to build `main.go` in your project to Dockerfile")
 
 	if err != nil {
 		return err

--- a/pkg/plugins/hybrid/v1alpha/scaffolds/internal/templates/dockerfile.go
+++ b/pkg/plugins/hybrid/v1alpha/scaffolds/internal/templates/dockerfile.go
@@ -57,20 +57,20 @@ COPY main.go main.go
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
-WORKDIR /
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 
-ENV HOME=/opt/helm
+ENV HOME=/opt/helm \
+    USER_ID=65532
 
-# Copy necessary files
-COPY watches.yaml ${HOME}/watches.yaml
-COPY helm-charts  ${HOME}/helm-charts
+# Copy necessary files with the right permissions
+COPY --chown=${USER_ID}:${USER_ID} watches.yaml ${HOME}/watches.yaml
+COPY --chown=${USER_ID}:${USER_ID} helm-charts  ${HOME}/helm-charts
 
 # Copy manager binary
 COPY --from=builder /workspace/manager .
 USER 65532:65532
+
+WORKDIR ${HOME}
 
 ENTRYPOINT ["/manager"]
 `

--- a/pkg/plugins/hybrid/v1alpha/scaffolds/internal/templates/dockerfile.go
+++ b/pkg/plugins/hybrid/v1alpha/scaffolds/internal/templates/dockerfile.go
@@ -53,6 +53,8 @@ RUN go mod download
 
 # Copy the go source
 COPY main.go main.go
+COPY api/ api/
+COPY controllers/ controllers/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go


### PR DESCRIPTION
This commit:
1. Adds additional customizations to be done in config/ as
   post-scaffolding step in init command.
2. Modify Dockerfile template.
3. Modify main.go to accept additional flags for watches.yaml and
   leader-election-id.

Signed-off-by: varshaprasad96 <varshaprasad96@gmail.com>

TODO: 

- [ ] Update the commit hash of helm-operator-plugin in `main.go` after the pr is merged. 
- [ ] Update testdata/ 