### PR TITLE
fix resource limits and scaffolding code

### DIFF
--- a/pkg/plugins/hybrid/v1alpha/init.go
+++ b/pkg/plugins/hybrid/v1alpha/init.go
@@ -153,16 +153,6 @@ func addInitCustomizations(projectName string) error {
 		return err
 	}
 
-	// Increase the default memory required.
-	err = projutil.ReplaceInFile(managerFile, "memory: 30Mi", "memory: 90Mi")
-	if err != nil {
-		return err
-	}
-	err = projutil.ReplaceInFile(managerFile, "memory: 20Mi", "memory: 60Mi")
-	if err != nil {
-		return err
-	}
-
 	// Remove the webhook option for the componentConfig since webhooks are not supported by helm
 	err = projutil.ReplaceInFile(filepath.Join("config", "manager", "controller_manager_config.yaml"),
 		"webhook:\n  port: 9443", "")

--- a/pkg/plugins/hybrid/v1alpha/scaffolds/internal/templates/main.go
+++ b/pkg/plugins/hybrid/v1alpha/scaffolds/internal/templates/main.go
@@ -227,6 +227,9 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
+	var leaderElectionID string
+	var watchesPath string
+	
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.StringVar(&watchesPath, "watches-file", "watches.yaml", "path to watches file")


### PR DESCRIPTION
This commit:
1. Removes the customizations made to resource limits in manager, as with
the default limits are already higher.
2. Fixes the watches and leaderelection Id flags which were missing in the
scaffolding.