### PR TITLE
Support BSD sed and older bash in test rule.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,12 +43,12 @@ all: test lint build
 # https://github.com/kubernetes-sigs/kubebuilder/pull/2287 targeting the kubebuilder
 # "tools-releases" branch. Make sure to look up the appropriate etcd version in the
 # kubernetes release notes for the minor version you're building tools for.
-ENVTEST_VERSION = $(shell go list -m k8s.io/client-go | cut -d" " -f2 | sed 's/^v0\.\([[:digit:]]\+\)\.[[:digit:]]\+$$/1.\1.x/')
+ENVTEST_VERSION = $(shell go list -m k8s.io/client-go | cut -d" " -f2 | sed 's/^v0\.\([[:digit:]]\{1,\}\)\.[[:digit:]]\{1,\}$$/1.\1.x/')
 TESTPKG ?= ./...
 # TODO: Modify this to use setup-envtest binary
 test: build
 	go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
-	source <(setup-envtest use -p env $(ENVTEST_VERSION)) && go test -race -covermode atomic -coverprofile cover.out $(TESTPKG)
+	eval $$(setup-envtest use -p env $(ENVTEST_VERSION)) && go test -race -covermode atomic -coverprofile cover.out $(TESTPKG)
 
 .PHONY: test-sanity
 test-sanity: generate fix ## Test repo formatting, linting, etc.


### PR DESCRIPTION
BSD sed (as shipped with MacOS) does not support `+` nor `\+` in regular expressions.
However it does support `\{1,\}` which does the same thing and is also supported by GNU sed.

Moreover, bash 3.2 (as shipped with MacOS) does not seem to support `source <(...)`, it seems to just do nothing.
Using plain eval seems to do the trick though.

Symptom of the former issue is:
```
source <(setup-envtest use -p env v0.22.1) && go test -race -covermode atomic -coverprofile cover.out ./...
version be a valid version, or simply 'latest' or 'latest-on-disk': unable to parse "v0.22.1" as a version stringshould be X.Y.Z, where Z may be '*','x', or left off entirely to denote a wildcard, optionally prefixed by ~|<|<=, and optionallyfollowed by ! (latest remote version)
```

And of the latter:
```
      unable to start control plane itself: failed to start the controlplane. retried 5 times: fork/exec /usr/local/kubebuilder/bin/etcd: no such file or directory
```
(even though the binaries _are_ fetched by `setup-envtest`)

Fixes: #117 