### PR TITLE
Allow marking releases stuck in a pending state as failed

### DIFF
--- a/pkg/client/actionclient.go
+++ b/pkg/client/actionclient.go
@@ -62,6 +62,7 @@ type ActionInterface interface {
 	Get(name string, opts ...GetOption) (*release.Release, error)
 	Install(name, namespace string, chrt *chart.Chart, vals map[string]interface{}, opts ...InstallOption) (*release.Release, error)
 	Upgrade(name, namespace string, chrt *chart.Chart, vals map[string]interface{}, opts ...UpgradeOption) (*release.Release, error)
+	MarkFailed(release *release.Release, reason string) error
 	Uninstall(name string, opts ...UninstallOption) (*release.UninstallReleaseResponse, error)
 	Reconcile(rel *release.Release) error
 }
@@ -178,6 +179,14 @@ func (c *actionClient) Upgrade(name, namespace string, chrt *chart.Chart, vals m
 		return nil, err
 	}
 	return rel, nil
+}
+
+func (c *actionClient) MarkFailed(rel *release.Release, reason string) error {
+	infoCopy := *rel.Info
+	releaseCopy := *rel
+	releaseCopy.Info = &infoCopy
+	releaseCopy.SetStatus(release.StatusFailed, reason)
+	return c.conf.Releases.Update(&releaseCopy)
 }
 
 func (c *actionClient) Uninstall(name string, opts ...UninstallOption) (*release.UninstallReleaseResponse, error) {

--- a/pkg/client/actionclient.go
+++ b/pkg/client/actionclient.go
@@ -62,7 +62,6 @@ type ActionInterface interface {
 	Get(name string, opts ...GetOption) (*release.Release, error)
 	Install(name, namespace string, chrt *chart.Chart, vals map[string]interface{}, opts ...InstallOption) (*release.Release, error)
 	Upgrade(name, namespace string, chrt *chart.Chart, vals map[string]interface{}, opts ...UpgradeOption) (*release.Release, error)
-	MarkFailed(release *release.Release, reason string) error
 	Uninstall(name string, opts ...UninstallOption) (*release.UninstallReleaseResponse, error)
 	Reconcile(rel *release.Release) error
 }
@@ -179,14 +178,6 @@ func (c *actionClient) Upgrade(name, namespace string, chrt *chart.Chart, vals m
 		return nil, err
 	}
 	return rel, nil
-}
-
-func (c *actionClient) MarkFailed(rel *release.Release, reason string) error {
-	infoCopy := *rel.Info
-	releaseCopy := *rel
-	releaseCopy.Info = &infoCopy
-	releaseCopy.SetStatus(release.StatusFailed, reason)
-	return c.conf.Releases.Update(&releaseCopy)
 }
 
 func (c *actionClient) Uninstall(name string, opts ...UninstallOption) (*release.UninstallReleaseResponse, error) {

--- a/pkg/client/actionclient.go
+++ b/pkg/client/actionclient.go
@@ -62,6 +62,7 @@ type ActionInterface interface {
 	Get(name string, opts ...GetOption) (*release.Release, error)
 	Install(name, namespace string, chrt *chart.Chart, vals map[string]interface{}, opts ...InstallOption) (*release.Release, error)
 	Upgrade(name, namespace string, chrt *chart.Chart, vals map[string]interface{}, opts ...UpgradeOption) (*release.Release, error)
+	Update(release *release.Release) error
 	Uninstall(name string, opts ...UninstallOption) (*release.UninstallReleaseResponse, error)
 	Reconcile(rel *release.Release) error
 }
@@ -178,6 +179,10 @@ func (c *actionClient) Upgrade(name, namespace string, chrt *chart.Chart, vals m
 		return nil, err
 	}
 	return rel, nil
+}
+
+func (c *actionClient) Update(rel *release.Release) error {
+	return c.conf.Releases.Update(rel)
 }
 
 func (c *actionClient) Uninstall(name string, opts ...UninstallOption) (*release.UninstallReleaseResponse, error) {

--- a/pkg/reconciler/internal/conditions/conditions.go
+++ b/pkg/reconciler/internal/conditions/conditions.go
@@ -41,6 +41,7 @@ const (
 	ReasonUpgradeError             = status.ConditionReason("UpgradeError")
 	ReasonReconcileError           = status.ConditionReason("ReconcileError")
 	ReasonUninstallError           = status.ConditionReason("UninstallError")
+	ReasonPendingError             = status.ConditionReason("PendingError")
 )
 
 func Initialized(stat corev1.ConditionStatus, reason status.ConditionReason, message interface{}) status.Condition {

--- a/pkg/reconciler/internal/fake/actionclient.go
+++ b/pkg/reconciler/internal/fake/actionclient.go
@@ -142,11 +142,6 @@ func (c *ActionClient) Upgrade(name, namespace string, chrt *chart.Chart, vals m
 	return c.HandleUpgrade()
 }
 
-func (c *ActionClient) MarkFailed(rel *release.Release, reason string) error {
-	c.MarkFaileds = append(c.MarkFaileds, MarkFailedCall{rel, reason})
-	return c.HandleMarkFailed()
-}
-
 func (c *ActionClient) Uninstall(name string, opts ...client.UninstallOption) (*release.UninstallReleaseResponse, error) {
 	c.Uninstalls = append(c.Uninstalls, UninstallCall{name, opts})
 	return c.HandleUninstall()

--- a/pkg/reconciler/internal/fake/actionclient.go
+++ b/pkg/reconciler/internal/fake/actionclient.go
@@ -74,18 +74,18 @@ func NewActionClient() ActionClient {
 		return func() error { return err }
 	}
 	return ActionClient{
-		Gets:       make([]GetCall, 0),
-		Installs:   make([]InstallCall, 0),
-		Upgrades:   make([]UpgradeCall, 0),
-		Uninstalls: make([]UninstallCall, 0),
-		Reconciles: make([]ReconcileCall, 0),
+		Gets:        make([]GetCall, 0),
+		Installs:    make([]InstallCall, 0),
+		Upgrades:    make([]UpgradeCall, 0),
+		Uninstalls:  make([]UninstallCall, 0),
+		Reconciles:  make([]ReconcileCall, 0),
 		MarkFaileds: make([]MarkFailedCall, 0),
 
-		HandleGet:       relFunc(errors.New("get not implemented")),
-		HandleInstall:   relFunc(errors.New("install not implemented")),
-		HandleUpgrade:   relFunc(errors.New("upgrade not implemented")),
-		HandleUninstall: uninstFunc(errors.New("uninstall not implemented")),
-		HandleReconcile: recFunc(errors.New("reconcile not implemented")),
+		HandleGet:        relFunc(errors.New("get not implemented")),
+		HandleInstall:    relFunc(errors.New("install not implemented")),
+		HandleUpgrade:    relFunc(errors.New("upgrade not implemented")),
+		HandleUninstall:  uninstFunc(errors.New("uninstall not implemented")),
+		HandleReconcile:  recFunc(errors.New("reconcile not implemented")),
 		HandleMarkFailed: recFunc(errors.New("mark failed not implemented")),
 	}
 }

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -61,14 +61,13 @@ const uninstallFinalizer = "uninstall-helm-release"
 
 // Reconciler reconciles a Helm object
 type Reconciler struct {
-	client               client.Client
-	actionClientGetter   helmclient.ActionClientGetter
-	actionConfigGetter   helmclient.ActionConfigGetter
-	valueTranslator      values.Translator
-	valueMapper          values.Mapper // nolint:staticcheck
-	eventRecorder        record.EventRecorder
-	preHooks             []hook.PreHook
-	postHooks            []hook.PostHook
+	client             client.Client
+	actionClientGetter helmclient.ActionClientGetter
+	valueTranslator    values.Translator
+	valueMapper        values.Mapper // nolint:staticcheck
+	eventRecorder      record.EventRecorder
+	preHooks           []hook.PreHook
+	postHooks          []hook.PostHook
 
 	log                     logr.Logger
 	gvk                     *schema.GroupVersionKind
@@ -173,16 +172,6 @@ func WithClient(cl client.Client) Option {
 func WithActionClientGetter(actionClientGetter helmclient.ActionClientGetter) Option {
 	return func(r *Reconciler) error {
 		r.actionClientGetter = actionClientGetter
-		return nil
-	}
-}
-
-// WithActionConfigGetter is an Option that configures a Reconciler's ActionConfigGetter
-//
-// A default ActionConfigGetter is used if this option is not configured.
-func WithActionConfigGetter(actionConfigGetter helmclient.ActionConfigGetter) Option {
-	return func(r *Reconciler) error {
-		r.actionConfigGetter = actionConfigGetter
 		return nil
 	}
 }
@@ -556,7 +545,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.
 		return ctrl.Result{}, err
 	}
 	if state == statePending {
-		return r.handlePending(obj, rel, &u, log)
+		return r.handlePending(actionClient, rel, &u, log)
 	}
 
 	u.UpdateStatus(updater.EnsureCondition(conditions.Irreconcilable(corev1.ConditionFalse, "", "")))
@@ -755,8 +744,8 @@ func (r *Reconciler) doUpgrade(actionClient helmclient.ActionInterface, u *updat
 	return rel, nil
 }
 
-func (r *Reconciler) handlePending(obj *unstructured.Unstructured, rel *release.Release, u *updater.Updater, log logr.Logger) (ctrl.Result, error) {
-	err := r.doHandlePending(obj, rel, log)
+func (r *Reconciler) handlePending(actionClient helmclient.ActionInterface, rel *release.Release, u *updater.Updater, log logr.Logger) (ctrl.Result, error) {
+	err := r.doHandlePending(actionClient, rel, log)
 	if err == nil {
 		err = errors.New("unknown error handling pending release")
 	}
@@ -765,7 +754,7 @@ func (r *Reconciler) handlePending(obj *unstructured.Unstructured, rel *release.
 	return ctrl.Result{}, err
 }
 
-func (r *Reconciler) doHandlePending(obj *unstructured.Unstructured, rel *release.Release, log logr.Logger) error {
+func (r *Reconciler) doHandlePending(actionClient helmclient.ActionInterface, rel *release.Release, log logr.Logger) error {
 	if r.markFailedAfter <= 0 {
 		return errors.New("Release is in a pending (locked) state and cannot be modified. User intervention is required.")
 	}
@@ -777,24 +766,19 @@ func (r *Reconciler) doHandlePending(obj *unstructured.Unstructured, rel *releas
 	}
 
 	log.Info("Marking release as failed", "releaseName", rel.Name)
-	err := r.markReleaseFailed(obj, rel, fmt.Sprintf("operator marked pending (locked) release as failed after state did not change for %v", r.markFailedAfter))
+	err := r.markReleaseFailed(actionClient, rel, fmt.Sprintf("operator marked pending (locked) release as failed after state did not change for %v", r.markFailedAfter))
 	if err != nil {
 		return fmt.Errorf("Failed to mark pending (locked) release as failed: %w", err)
 	}
 	return fmt.Errorf("marked release %s as failed to allow upgrade to succeed in next reconcile attempt", rel.Name)
 }
 
-func (r *Reconciler) markReleaseFailed(obj *unstructured.Unstructured, rel *release.Release, reason string) error {
+func (r *Reconciler) markReleaseFailed(actionClient helmclient.ActionInterface, rel *release.Release, reason string) error {
 	infoCopy := *rel.Info
 	releaseCopy := *rel
 	releaseCopy.Info = &infoCopy
 	releaseCopy.SetStatus(release.StatusFailed, reason)
-
- 	actionConfig, err := r.actionConfigGetter.ActionConfigFor(obj)
- 	if err != nil {
- 		return err
-	}
-	return actionConfig.Releases.Update(&releaseCopy)
+	return actionClient.Update(&releaseCopy)
 }
 
 func (r *Reconciler) reportOverrideEvents(obj runtime.Object) {
@@ -871,8 +855,8 @@ func (r *Reconciler) addDefaults(mgr ctrl.Manager, controllerName string) {
 		r.log = ctrl.Log.WithName("controllers").WithName("Helm")
 	}
 	if r.actionClientGetter == nil {
-		r.actionConfigGetter = helmclient.NewActionConfigGetter(mgr.GetConfig(), mgr.GetRESTMapper(), r.log)
-		r.actionClientGetter = helmclient.NewActionClientGetter(r.actionConfigGetter)
+		actionConfigGetter := helmclient.NewActionConfigGetter(mgr.GetConfig(), mgr.GetRESTMapper(), r.log)
+		r.actionClientGetter = helmclient.NewActionClientGetter(actionConfigGetter)
 	}
 	if r.eventRecorder == nil {
 		r.eventRecorder = mgr.GetEventRecorderFor(controllerName)

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -498,11 +498,10 @@ var _ = Describe("Reconciler", func() {
 						fakeClient.HandleGet = func() (*release.Release, error) {
 							return exampleRelease, nil
 						}
-						fakeClient.HandleMarkFailed = func() error {
-							return nil
-						}
 						return &fakeClient, nil
 					})
+					//TODO: add actionConfigGetter fake
+					//r.actionConfigGetter =
 				})
 				AfterEach(func() {
 					r.actionClientGetter = nil
@@ -515,7 +514,6 @@ var _ = Describe("Reconciler", func() {
 						Expect(res).To(Equal(reconcile.Result{}))
 						Expect(err).ToNot(BeNil())
 						Expect(err).To(MatchError("marked release example-release as failed to allow upgrade to succeed in next reconcile attempt"))
-						Expect(len(fakeClient.MarkFaileds)).Should(Equal(1))
 					})
 				})
 

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -385,8 +385,8 @@ var _ = Describe("Reconciler", func() {
 		})
 		var _ = Describe("WithMarkedFailAfter", func() {
 			It("should set the reconciler mark failed after duration", func() {
-				Expect(WithMarkFailedAfter(1*time.Minute)(r)).To(Succeed())
-				Expect(r.markFailedAfter).To(Equal(1*time.Minute))
+				Expect(WithMarkFailedAfter(1 * time.Minute)(r)).To(Succeed())
+				Expect(r.markFailedAfter).To(Equal(1 * time.Minute))
 			})
 		})
 	})
@@ -531,7 +531,7 @@ var _ = Describe("Reconciler", func() {
 
 				When("time since last deployment is higher than markFiledAfter duration", func () {
 					It("should return duration until the release will be marked as failed", func () {
-						r.markFailedAfter = 10*time.Minute
+						r.markFailedAfter = 10 * time.Minute
 						res, err := r.Reconcile(ctx, req)
 						Expect(res).To(Equal(reconcile.Result{}))
 						Expect(err).ToNot(BeNil())

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -498,10 +498,11 @@ var _ = Describe("Reconciler", func() {
 						fakeClient.HandleGet = func() (*release.Release, error) {
 							return exampleRelease, nil
 						}
+						fakeClient.HandleUpdate = func() error {
+							return nil
+						}
 						return &fakeClient, nil
 					})
-					//TODO: add actionConfigGetter fake
-					//r.actionConfigGetter =
 				})
 				AfterEach(func() {
 					r.actionClientGetter = nil

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -529,8 +529,8 @@ var _ = Describe("Reconciler", func() {
 					})
 				})
 
-				When("time since last deployment is higher than markFiledAfter duration", func () {
-					It("should return duration until the release will be marked as failed", func () {
+				When("time since last deployment is higher than markFiledAfter duration", func() {
+					It("should return duration until the release will be marked as failed", func() {
 						r.markFailedAfter = 10 * time.Minute
 						res, err := r.Reconcile(ctx, req)
 						Expect(res).To(Equal(reconcile.Result{}))


### PR DESCRIPTION
PR to discuss how to recover from pending state.
This is our current implementation used in https://github.com/stackrox/helm-operator

Fixes #94 

Currently if the Helm releases exits unexpectedly (i.e. due to node crash or a bug) the pending state of a Helm release is never released and leads to an infinite reconciliation loop.

To automatically resolve pending states the reconciler now takes an option via `WithMarkFailedAfter` which configures a timeout after the pending state is handled as a failure.



**ToDo**

- [x] Add Tests
- [ ] Only mark failed on Operator owned Helm secrets