### PR TITLE
fix(helm-operator): do not send empty patch requests to kube apiserver

### DIFF
--- a/pkg/client/actionclient.go
+++ b/pkg/client/actionclient.go
@@ -264,9 +264,17 @@ func createPatch(existing runtime.Object, expected *resource.Info) ([]byte, apit
 	if err != nil {
 		return nil, apitypes.StrategicMergePatchType, err
 	}
-
 	patch, err := strategicpatch.CreateThreeWayMergePatch(expectedJSON, expectedJSON, existingJSON, patchMeta, true)
-	return patch, apitypes.StrategicMergePatchType, err
+	if err != nil {
+		return nil, apitypes.StrategicMergePatchType, err
+	}
+
+	// An empty patch could be in the form of "{}" which represents an empty map out of the 3-way merge;
+	// filter them out here too to avoid sending the apiserver empty patch requests.
+	if len(patch) == 0 || bytes.Equal(patch, []byte("{}")) {
+		return nil, apitypes.StrategicMergePatchType, nil
+	}
+	return patch, apitypes.StrategicMergePatchType, nil
 }
 
 func createJSONMergePatch(existingJSON, expectedJSON []byte) ([]byte, error) {

--- a/pkg/client/actionclient_test.go
+++ b/pkg/client/actionclient_test.go
@@ -470,7 +470,7 @@ var _ = Describe("ActionClient", func() {
 			}
 			patch, patchType, err := createPatch(o1, o2)
 			Expect(err).To(BeNil())
-			Expect(string(patch)).To(Equal(`{}`))
+			Expect(patch).To(BeNil())
 			Expect(patchType).To(Equal(apitypes.StrategicMergePatchType))
 		})
 		It("replaces incorrect fields in core types", func() {
@@ -511,7 +511,7 @@ var _ = Describe("ActionClient", func() {
 			}
 			patch, patchType, err := createPatch(o1, o2)
 			Expect(err).To(BeNil())
-			Expect(string(patch)).To(Equal(`{}`))
+			Expect(patch).To(BeNil())
 			Expect(patchType).To(Equal(apitypes.StrategicMergePatchType))
 		})
 	})


### PR DESCRIPTION
The change filters out empty patches generated from the 3-way merge,
which could be in the form of the "{}" byte array that
represents an empty map.

Reference: https://github.com/operator-framework/operator-sdk/pull/4957
Co-authored-by: Cheuk Lam