### PR TITLE
New Reconciler Option: SkipPrimaryGVKSchemeRegistration

### DIFF
--- a/pkg/reconciler/reconciler_suite_test.go
+++ b/pkg/reconciler/reconciler_suite_test.go
@@ -41,6 +41,7 @@ var (
 	cfg     *rest.Config
 
 	gvk  = schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "TestApp"}
+	gv   = schema.GroupVersion{Group: "example.com", Version: "v1"}
 	chrt = testutil.MustLoadChart("../../pkg/internal/testdata/test-chart-1.2.0.tgz")
 )
 

--- a/pkg/reconciler/reconciler_suite_test.go
+++ b/pkg/reconciler/reconciler_suite_test.go
@@ -41,7 +41,7 @@ var (
 	cfg     *rest.Config
 
 	gvk  = schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "TestApp"}
-	gv   = schema.GroupVersion{Group: "example.com", Version: "v1"}
+	gv   = gvk.GroupVersion()
 	chrt = testutil.MustLoadChart("../../pkg/internal/testdata/test-chart-1.2.0.tgz")
 )
 


### PR DESCRIPTION
Add a new Reconciler option `SkipGenericGVKSchemeRegistration `, which can be used by users who prefer their
custom scheme setup over the generic scheme setup currently being done by the reconciler.

Signed-off-by: Moritz Clasmeier <moritz@stackrox.com>
