### PR TITLE
Expose generic mechanism for configuring the controller builder

### DIFF
--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -79,6 +79,7 @@ type Reconciler struct {
 	reconcilePeriod                  time.Duration
 	maxHistory                       int
 	skipPrimaryGVKSchemeRegistration bool
+	controllerSetupFuncs             []ControllerSetupFunc
 
 	annotSetupOnce       sync.Once
 	annotations          map[string]struct{}
@@ -143,6 +144,13 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	if err := r.setupWatches(mgr, c); err != nil {
 		return err
+	}
+
+	for _, f := range r.controllerSetupFuncs {
+		err = f(c)
+		if err != nil {
+			return fmt.Errorf("failed to execute custom controller setup function: %v", err)
+		}
 	}
 
 	r.log.Info("Watching resource",
@@ -477,6 +485,30 @@ func WithSelector(s metav1.LabelSelector) Option {
 		return nil
 	}
 }
+
+// WithControllerSetupFunc is an Option that allows customizing a controller before it is started.
+// The only supported customization here is adding additional Watch sources to the controller.
+func WithControllerSetupFunc(f ControllerSetupFunc) Option {
+	return func(r *Reconciler) error {
+		r.controllerSetupFuncs = append(r.controllerSetupFuncs, f)
+		return nil
+	}
+}
+
+// ControllerSetup allows restricted access to the Controller using the WithControllerSetupFunc option.
+// Currently the only supposed configuration is adding additional watchers do the controller.
+type ControllerSetup interface {
+	// Watch takes events provided by a Source and uses the EventHandler to
+	// enqueue reconcile.Requests in response to the events.
+	//
+	// Watch may be provided one or more Predicates to filter events before
+	// they are given to the EventHandler.  Events will be passed to the
+	// EventHandler if all provided Predicates evaluate to true.
+	Watch(src source.Source, eventhandler handler.EventHandler, predicates ...predicate.Predicate) error
+}
+
+// ControllerSetupFunc allows configuring a controller's builder.
+type ControllerSetupFunc func(c ControllerSetup) error
 
 // Reconcile reconciles a CR that defines a Helm v3 release.
 //

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -47,6 +47,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 	"sigs.k8s.io/yaml"
 
 	"github.com/operator-framework/helm-operator-plugins/internal/sdk/controllerutil"
@@ -58,6 +59,7 @@ import (
 	"github.com/operator-framework/helm-operator-plugins/pkg/reconciler/internal/conditions"
 	helmfake "github.com/operator-framework/helm-operator-plugins/pkg/reconciler/internal/fake"
 	"github.com/operator-framework/helm-operator-plugins/pkg/values"
+	sdkhandler "github.com/operator-framework/operator-lib/handler"
 )
 
 // custom is used within the reconciler test suite as underlying type for the GVK scheme.
@@ -1327,6 +1329,43 @@ var _ = Describe("Reconciler", func() {
 			parameterizedReconcilerTests(reconcilerTestSuiteOpts{customGVKSchemeSetup: true})
 		})
 
+	})
+
+	var _ = Describe("Test custom controller setup", func() {
+		var (
+			mgr                   manager.Manager
+			r                     *Reconciler
+			err                   error
+			controllerSetupCalled bool
+		)
+		additionalGVK := schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "SomeOtherKind"}
+		setupController := func(c ControllerSetup) error {
+			controllerSetupCalled = true
+			u := &unstructured.Unstructured{}
+			u.SetGroupVersionKind(additionalGVK)
+			return c.Watch(&source.Kind{Type: u}, &sdkhandler.InstrumentedEnqueueRequestForObject{})
+		}
+
+		It("Registering builder setup function for reconciler works", func() {
+			mgr = getManagerOrFail()
+			r, err = New(
+				WithGroupVersionKind(gvk),
+				WithChart(chrt),
+				WithInstallAnnotations(annotation.InstallDescription{}),
+				WithUpgradeAnnotations(annotation.UpgradeDescription{}),
+				WithUninstallAnnotations(annotation.UninstallDescription{}),
+				WithOverrideValues(map[string]string{
+					"image.repository": "custom-nginx",
+				}),
+				WithControllerSetupFunc(setupController),
+			)
+			Expect(err).To(BeNil())
+		})
+
+		It("Setting up reconciler with manager causes custom builder setup to be executed", func() {
+			Expect(r.SetupWithManager(mgr)).To(Succeed())
+			Expect(controllerSetupCalled).To(BeTrue())
+		})
 	})
 })
 


### PR DESCRIPTION
Expose generic mechanism for configuring the controller, allowing to add additional watch sources.

Signed-off-by: Moritz Clasmeier <moritz@stackrox.com>