### PR TITLE
New Reconciler Extensions

### DIFF
--- a/pkg/extension/extension.go
+++ b/pkg/extension/extension.go
@@ -1,0 +1,74 @@
+package extension
+
+import (
+	"context"
+
+	"helm.sh/helm/v3/pkg/chartutil"
+	"helm.sh/helm/v3/pkg/release"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/rest"
+)
+
+// ReconcilerExtension defines an extension for the reconciler.
+// It consists of several sub-interfaces.
+type ReconcilerExtension interface {
+	Name() string
+	BeginReconciliationExtension
+	EndReconciliationExtension
+}
+
+// BeginReconciliationExtension defines the extension point to execute at the beginning of a reconciliation flow.
+type BeginReconciliationExtension interface {
+	BeginReconcile(ctx context.Context, reconciliationContext *Context, obj *unstructured.Unstructured) error
+}
+
+// EndReconciliationExtension defiens the extension point to execute at the end of a reconciliation flow.
+type EndReconciliationExtension interface {
+	EndReconcile(ctx context.Context, reconciliationContext *Context, obj *unstructured.Unstructured) error
+}
+
+// NoOpReconcilerExtension implements all extension methods as no-ops and can be used for convenience
+// when only a subset of the available methods needs to be implemented.
+type NoOpReconcilerExtension struct{}
+
+func (e NoOpReconcilerExtension) BeginReconcile(ctx context.Context, reconciliationContext *Context, obj *unstructured.Unstructured) error {
+	return nil
+}
+
+func (e NoOpReconcilerExtension) EndReconcile(ctx context.Context, reconciliationContext *Context, obj *unstructured.Unstructured) error {
+	return nil
+}
+
+// Context can be used for providing extension methods will more context about the reconciliation flow.
+// This contains data objects which can be useful for specific extensions but might not be required for all.
+type Context struct {
+	KubernetesConfig *rest.Config
+	HelmRelease      *release.Release
+	HelmValues       chartutil.Values
+}
+
+// GetHelmRelease is a nil-safe getter retrieving the Helm release information from a reconciliation context, if available.
+// Returns an empty Helm release if the release information is not available at the time the extension point is called.
+func (c *Context) GetHelmRelease() release.Release {
+	if c == nil || c.HelmRelease == nil {
+		return release.Release{}
+	}
+	return *c.HelmRelease
+}
+
+// GetHelmValues is a nil-safe getter retrieving the Helm values information from a reconciliation context, if available.
+// Returns nil if the Helm value are not available at the time the extension point is called.
+func (c *Context) GetHelmValues() chartutil.Values {
+	if c == nil {
+		return nil
+	}
+	return c.HelmValues
+}
+
+// GetKubernetesConfig is a nil-safe getter for retrieving the Kubernetes config from a reconciliation context, if available.
+func (c *Context) GetKubernetesConfig() *rest.Config {
+	if c == nil {
+		return nil
+	}
+	return c.KubernetesConfig
+}

--- a/pkg/hook/hook.go
+++ b/pkg/hook/hook.go
@@ -17,28 +17,69 @@ limitations under the License.
 package hook
 
 import (
+	"context"
+
 	"github.com/go-logr/logr"
+	"github.com/operator-framework/helm-operator-plugins/pkg/extension"
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/release"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-type PreHook interface {
-	Exec(*unstructured.Unstructured, chartutil.Values, logr.Logger) error
+type PreHookFunc func(context.Context, *unstructured.Unstructured, logr.Logger) error
+
+func WrapPreHookFunc(f PreHookFunc) PreHookFunc {
+	wrappedF := func(ctx context.Context, obj *unstructured.Unstructured, log logr.Logger) error {
+		err := f(ctx, obj, log)
+		if err != nil {
+			log.Error(err, "pre-release hook failed")
+		}
+		return nil
+	}
+
+	return PreHookFunc(wrappedF)
 }
 
-type PreHookFunc func(*unstructured.Unstructured, chartutil.Values, logr.Logger) error
+func WrapPostHookFunc(f PostHookFunc) PostHookFunc {
+	wrappedF := func(ctx context.Context, obj *unstructured.Unstructured, rel release.Release, vals chartutil.Values, log logr.Logger) error {
+		err := f(ctx, obj, rel, vals, log)
+		if err != nil {
+			log.Error(err, "post-release hook failed", "name", rel.Name, "version", rel.Version)
+		}
+		return nil
+	}
 
-func (f PreHookFunc) Exec(obj *unstructured.Unstructured, vals chartutil.Values, log logr.Logger) error {
-	return f(obj, vals, log)
+	return PostHookFunc(wrappedF)
 }
 
-type PostHook interface {
-	Exec(*unstructured.Unstructured, release.Release, logr.Logger) error
+func (h PreHookFunc) Name() string {
+	return "pre-hook"
 }
 
-type PostHookFunc func(*unstructured.Unstructured, release.Release, logr.Logger) error
-
-func (f PostHookFunc) Exec(obj *unstructured.Unstructured, rel release.Release, log logr.Logger) error {
-	return f(obj, rel, log)
+func (h PreHookFunc) BeginReconcile(ctx context.Context, reconciliationContext *extension.Context, obj *unstructured.Unstructured) error {
+	log := logr.FromContextOrDiscard(ctx)
+	return h(ctx, obj, log)
 }
+
+func (h PreHookFunc) EndReconcile(ctx context.Context, reconciliationContext *extension.Context, obj *unstructured.Unstructured) error {
+	return nil
+}
+
+var _ extension.ReconcilerExtension = (PreHookFunc)(nil)
+
+type PostHookFunc func(context.Context, *unstructured.Unstructured, release.Release, chartutil.Values, logr.Logger) error
+
+func (h PostHookFunc) Name() string {
+	return "post-hook"
+}
+
+func (f PostHookFunc) BeginReconcile(ctx context.Context, reconciliationContext *extension.Context, obj *unstructured.Unstructured) error {
+	return nil
+}
+
+func (f PostHookFunc) EndReconcile(ctx context.Context, reconciliationContext *extension.Context, obj *unstructured.Unstructured) error {
+	log := logr.FromContextOrDiscard(ctx)
+	return f(ctx, obj, reconciliationContext.GetHelmRelease(), reconciliationContext.GetHelmValues(), log)
+}
+
+var _ extension.ReconcilerExtension = (*PostHookFunc)(nil)

--- a/pkg/hook/hook_test.go
+++ b/pkg/hook/hook_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package hook_test
 
 import (
+	"context"
+
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -24,29 +26,32 @@ import (
 	"helm.sh/helm/v3/pkg/release"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	. "github.com/operator-framework/helm-operator-plugins/pkg/hook"
+	"github.com/operator-framework/helm-operator-plugins/pkg/extension"
+	"github.com/operator-framework/helm-operator-plugins/pkg/hook"
 )
 
 var _ = Describe("Hook", func() {
 	var _ = Describe("PreHookFunc", func() {
 		It("should implement the PreHook interface", func() {
 			called := false
-			var h PreHook = PreHookFunc(func(*unstructured.Unstructured, chartutil.Values, logr.Logger) error {
-				called = true
-				return nil
-			})
-			Expect(h.Exec(nil, nil, logr.Discard())).To(Succeed())
+			var h extension.ReconcilerExtension = hook.PreHookFunc(
+				func(context.Context, *unstructured.Unstructured, logr.Logger) error {
+					called = true
+					return nil
+				})
+			Expect(h.BeginReconcile(context.TODO(), nil, nil)).To(Succeed())
 			Expect(called).To(BeTrue())
 		})
 	})
 	var _ = Describe("PostHookFunc", func() {
 		It("should implement the PostHook interface", func() {
 			called := false
-			var h PostHook = PostHookFunc(func(*unstructured.Unstructured, release.Release, logr.Logger) error {
-				called = true
-				return nil
-			})
-			Expect(h.Exec(nil, release.Release{}, logr.Discard())).To(Succeed())
+			var h extension.ReconcilerExtension = hook.PostHookFunc(
+				func(context.Context, *unstructured.Unstructured, release.Release, chartutil.Values, logr.Logger) error {
+					called = true
+					return nil
+				})
+			Expect(h.EndReconcile(context.TODO(), nil, nil)).To(Succeed())
 			Expect(called).To(BeTrue())
 		})
 	})

--- a/pkg/reconciler/extensions.go
+++ b/pkg/reconciler/extensions.go
@@ -1,0 +1,51 @@
+package reconciler
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/operator-framework/helm-operator-plugins/pkg/extension"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type extensions []extension.ReconcilerExtension
+
+func (es extensions) forEach(f func(e extension.ReconcilerExtension) error) error {
+	var err error
+	for _, e := range es {
+		err = f(e)
+		if err != nil {
+			return err
+		}
+	}
+	return err
+}
+
+func (r *Reconciler) extBeginReconcile(ctx context.Context, reconciliationContext *extension.Context, obj *unstructured.Unstructured) error {
+	return r.extensions.forEach(func(ext extension.ReconcilerExtension) error {
+		e, ok := ext.(extension.BeginReconciliationExtension)
+		if !ok {
+			return nil
+		}
+		err := e.BeginReconcile(ctx, reconciliationContext, obj)
+		if err != nil {
+			return fmt.Errorf("extension %s failed during begin-reconcile phase: %v", ext.Name(), err)
+		}
+		return nil
+	})
+}
+
+func (r *Reconciler) extEndReconcile(ctx context.Context, reconciliationContext *extension.Context, obj *unstructured.Unstructured) error {
+	return r.extensions.forEach(func(ext extension.ReconcilerExtension) error {
+		e, ok := ext.(extension.EndReconciliationExtension)
+		if !ok {
+			return nil
+		}
+
+		err := e.EndReconcile(ctx, reconciliationContext, obj)
+		if err != nil {
+			return fmt.Errorf("extension %s failed during end-reconcile phase: %v", ext.Name(), err)
+		}
+		return nil
+	})
+}


### PR DESCRIPTION
    Implement general extensions which are better suited for hybrid operators with customized reconciliation workflows.
    Shows how pre/post hooks can be implemented in terms of extensions.
    
    Signed-off-by: Moritz Clasmeier <moritz@stackrox.com>
    
This PR demonstrates on implementation strategy for extensions.
Looking forward to reviews & discussion.

Based on the discussions we've had, I'd like to comment on a few aspects:

* It was suggested to go forward with a minimal interface that would suit our needs: The new interface is minimal in the sense that it only contains two methods, similar to the PreHook/PostHook mechanism.

* This proposal tries to keep most of the advantages of static typing but in order to make future extensibility easy there is a `NoOp` value, which can be used for inheriting no-op-default-implementations for extension methods.

* The nomenclature has been changed: It's not anymore pre- & post-reconcile, but rather begin- & end-reconcile, to highlight that these custom steps are still to be regarded as part of the overall reconciliation workflow.

* The logger is now injected into the context as done in the kubebuilder scaffolding.

* In this proposal I am deliberately not using `context.Context` for untyped injection of more data potentially required by extensions because the understanding I have acquired from my research suggests that this is in rather sharp contradiction to the current best-practices. For instance, the [official documentation](https://pkg.go.dev/context) says "Use context Values only for request-scoped data that transits processes and APIs, **not for passing optional parameters to functions.**". This is not 100% our use-case, but I understand it so that also our use-case would be questionable. This is against what we have discussed in our meeting. What I have done instead is I created a dedicated "reconciliation context", that is passed to all extension methods and is distinct from `context.Context` but used for providing all sorts of potentially-available context for the reconciliation workflow. My hope here is that this would allow for easy extensibility in the future and would help us to not box ourselves in.

* I have also shown how to implement PreHooks and PostHooks using the general extension interface. This compatibility code could remain, but doesn't have to remain.

I will be back from vacation on April 4, opening this draft so that you can already have a look at the current state. @varshaprasad96 @joelanford @misberner 
