### PR TITLE
New Reconciler Extensions (based on context.Context information passing)

### DIFF
--- a/pkg/extension/extension.go
+++ b/pkg/extension/extension.go
@@ -1,0 +1,74 @@
+package extension
+
+import (
+	"context"
+
+	"helm.sh/helm/v3/pkg/chartutil"
+	"helm.sh/helm/v3/pkg/release"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/rest"
+)
+
+// ReconcilerExtension defines an extension for the reconciler.
+// It consists of several sub-interfaces.
+type ReconcilerExtension interface {
+	Name() string
+	BeginReconciliationExtension
+	EndReconciliationExtension
+}
+
+// BeginReconciliationExtension defines the extension point to execute at the beginning of a reconciliation flow.
+type BeginReconciliationExtension interface {
+	BeginReconcile(ctx context.Context, reconciliationContext *Context, obj *unstructured.Unstructured) error
+}
+
+// EndReconciliationExtension defiens the extension point to execute at the end of a reconciliation flow.
+type EndReconciliationExtension interface {
+	EndReconcile(ctx context.Context, reconciliationContext *Context, obj *unstructured.Unstructured) error
+}
+
+// NoOpReconcilerExtension implements all extension methods as no-ops and can be used for convenience
+// when only a subset of the available methods needs to be implemented.
+type NoOpReconcilerExtension struct{}
+
+func (e NoOpReconcilerExtension) BeginReconcile(ctx context.Context, reconciliationContext *Context, obj *unstructured.Unstructured) error {
+	return nil
+}
+
+func (e NoOpReconcilerExtension) EndReconcile(ctx context.Context, reconciliationContext *Context, obj *unstructured.Unstructured) error {
+	return nil
+}
+
+// Context can be used for providing extension methods will more context about the reconciliation flow.
+// This contains data objects which can be useful for specific extensions but might not be required for all.
+type Context struct {
+	KubernetesConfig *rest.Config
+	HelmRelease      *release.Release
+	HelmValues       chartutil.Values
+}
+
+// GetHelmRelease is a nil-safe getter retrieving the Helm release information from a reconciliation context, if available.
+// Returns an empty Helm release if the release information is not available at the time the extension point is called.
+func (c *Context) GetHelmRelease() release.Release {
+	if c == nil || c.HelmRelease == nil {
+		return release.Release{}
+	}
+	return *c.HelmRelease
+}
+
+// GetHelmValues is a nil-safe getter retrieving the Helm values information from a reconciliation context, if available.
+// Returns nil if the Helm value are not available at the time the extension point is called.
+func (c *Context) GetHelmValues() chartutil.Values {
+	if c == nil {
+		return nil
+	}
+	return c.HelmValues
+}
+
+// GetKubernetesConfig is a nil-safe getter for retrieving the Kubernetes config from a reconciliation context, if available.
+func (c *Context) GetKubernetesConfig() *rest.Config {
+	if c == nil {
+		return nil
+	}
+	return c.KubernetesConfig
+}

--- a/pkg/hook/hook.go
+++ b/pkg/hook/hook.go
@@ -17,28 +17,69 @@ limitations under the License.
 package hook
 
 import (
+	"context"
+
 	"github.com/go-logr/logr"
+	"github.com/operator-framework/helm-operator-plugins/pkg/extension"
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/release"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-type PreHook interface {
-	Exec(*unstructured.Unstructured, chartutil.Values, logr.Logger) error
+type PreHookFunc func(context.Context, *unstructured.Unstructured, logr.Logger) error
+
+func WrapPreHookFunc(f PreHookFunc) PreHookFunc {
+	wrappedF := func(ctx context.Context, obj *unstructured.Unstructured, log logr.Logger) error {
+		err := f(ctx, obj, log)
+		if err != nil {
+			log.Error(err, "pre-release hook failed")
+		}
+		return nil
+	}
+
+	return PreHookFunc(wrappedF)
 }
 
-type PreHookFunc func(*unstructured.Unstructured, chartutil.Values, logr.Logger) error
+func WrapPostHookFunc(f PostHookFunc) PostHookFunc {
+	wrappedF := func(ctx context.Context, obj *unstructured.Unstructured, rel release.Release, vals chartutil.Values, log logr.Logger) error {
+		err := f(ctx, obj, rel, vals, log)
+		if err != nil {
+			log.Error(err, "post-release hook failed", "name", rel.Name, "version", rel.Version)
+		}
+		return nil
+	}
 
-func (f PreHookFunc) Exec(obj *unstructured.Unstructured, vals chartutil.Values, log logr.Logger) error {
-	return f(obj, vals, log)
+	return PostHookFunc(wrappedF)
 }
 
-type PostHook interface {
-	Exec(*unstructured.Unstructured, release.Release, logr.Logger) error
+func (h PreHookFunc) Name() string {
+	return "pre-hook"
 }
 
-type PostHookFunc func(*unstructured.Unstructured, release.Release, logr.Logger) error
-
-func (f PostHookFunc) Exec(obj *unstructured.Unstructured, rel release.Release, log logr.Logger) error {
-	return f(obj, rel, log)
+func (h PreHookFunc) BeginReconcile(ctx context.Context, reconciliationContext *extension.Context, obj *unstructured.Unstructured) error {
+	log := logr.FromContextOrDiscard(ctx)
+	return h(ctx, obj, log)
 }
+
+func (h PreHookFunc) EndReconcile(ctx context.Context, reconciliationContext *extension.Context, obj *unstructured.Unstructured) error {
+	return nil
+}
+
+var _ extension.ReconcilerExtension = (PreHookFunc)(nil)
+
+type PostHookFunc func(context.Context, *unstructured.Unstructured, release.Release, chartutil.Values, logr.Logger) error
+
+func (h PostHookFunc) Name() string {
+	return "post-hook"
+}
+
+func (f PostHookFunc) BeginReconcile(ctx context.Context, reconciliationContext *extension.Context, obj *unstructured.Unstructured) error {
+	return nil
+}
+
+func (f PostHookFunc) EndReconcile(ctx context.Context, reconciliationContext *extension.Context, obj *unstructured.Unstructured) error {
+	log := logr.FromContextOrDiscard(ctx)
+	return f(ctx, obj, reconciliationContext.GetHelmRelease(), reconciliationContext.GetHelmValues(), log)
+}
+
+var _ extension.ReconcilerExtension = (*PostHookFunc)(nil)

--- a/pkg/hook/hook.go
+++ b/pkg/hook/hook.go
@@ -56,12 +56,12 @@ func (h PreHookFunc) Name() string {
 	return "pre-hook"
 }
 
-func (h PreHookFunc) BeginReconcile(ctx context.Context, reconciliationContext *extension.Context, obj *unstructured.Unstructured) error {
+func (h PreHookFunc) BeginReconcile(ctx context.Context, obj *unstructured.Unstructured) error {
 	log := logr.FromContextOrDiscard(ctx)
 	return h(ctx, obj, log)
 }
 
-func (h PreHookFunc) EndReconcile(ctx context.Context, reconciliationContext *extension.Context, obj *unstructured.Unstructured) error {
+func (h PreHookFunc) EndReconcile(ctx context.Context, obj *unstructured.Unstructured) error {
 	return nil
 }
 
@@ -73,13 +73,13 @@ func (h PostHookFunc) Name() string {
 	return "post-hook"
 }
 
-func (f PostHookFunc) BeginReconcile(ctx context.Context, reconciliationContext *extension.Context, obj *unstructured.Unstructured) error {
+func (f PostHookFunc) BeginReconcile(ctx context.Context, obj *unstructured.Unstructured) error {
 	return nil
 }
 
-func (f PostHookFunc) EndReconcile(ctx context.Context, reconciliationContext *extension.Context, obj *unstructured.Unstructured) error {
+func (f PostHookFunc) EndReconcile(ctx context.Context, obj *unstructured.Unstructured) error {
 	log := logr.FromContextOrDiscard(ctx)
-	return f(ctx, obj, reconciliationContext.GetHelmRelease(), reconciliationContext.GetHelmValues(), log)
+	return f(ctx, obj, extension.HelmReleaseFromContext(ctx), extension.HelmValuesFromContext(ctx), log)
 }
 
 var _ extension.ReconcilerExtension = (*PostHookFunc)(nil)

--- a/pkg/hook/hook_test.go
+++ b/pkg/hook/hook_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package hook_test
 
 import (
+	"context"
+
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -24,29 +26,32 @@ import (
 	"helm.sh/helm/v3/pkg/release"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	. "github.com/operator-framework/helm-operator-plugins/pkg/hook"
+	"github.com/operator-framework/helm-operator-plugins/pkg/extension"
+	"github.com/operator-framework/helm-operator-plugins/pkg/hook"
 )
 
 var _ = Describe("Hook", func() {
 	var _ = Describe("PreHookFunc", func() {
 		It("should implement the PreHook interface", func() {
 			called := false
-			var h PreHook = PreHookFunc(func(*unstructured.Unstructured, chartutil.Values, logr.Logger) error {
-				called = true
-				return nil
-			})
-			Expect(h.Exec(nil, nil, logr.Discard())).To(Succeed())
+			var h extension.ReconcilerExtension = hook.PreHookFunc(
+				func(context.Context, *unstructured.Unstructured, logr.Logger) error {
+					called = true
+					return nil
+				})
+			Expect(h.BeginReconcile(context.TODO(), nil, nil)).To(Succeed())
 			Expect(called).To(BeTrue())
 		})
 	})
 	var _ = Describe("PostHookFunc", func() {
 		It("should implement the PostHook interface", func() {
 			called := false
-			var h PostHook = PostHookFunc(func(*unstructured.Unstructured, release.Release, logr.Logger) error {
-				called = true
-				return nil
-			})
-			Expect(h.Exec(nil, release.Release{}, logr.Discard())).To(Succeed())
+			var h extension.ReconcilerExtension = hook.PostHookFunc(
+				func(context.Context, *unstructured.Unstructured, release.Release, chartutil.Values, logr.Logger) error {
+					called = true
+					return nil
+				})
+			Expect(h.EndReconcile(context.TODO(), nil, nil)).To(Succeed())
 			Expect(called).To(BeTrue())
 		})
 	})

--- a/pkg/hook/hook_test.go
+++ b/pkg/hook/hook_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Hook", func() {
 					called = true
 					return nil
 				})
-			Expect(h.BeginReconcile(context.TODO(), nil, nil)).To(Succeed())
+			Expect(h.BeginReconcile(context.TODO(), nil)).To(Succeed())
 			Expect(called).To(BeTrue())
 		})
 	})
@@ -51,7 +51,7 @@ var _ = Describe("Hook", func() {
 					called = true
 					return nil
 				})
-			Expect(h.EndReconcile(context.TODO(), nil, nil)).To(Succeed())
+			Expect(h.EndReconcile(context.TODO(), nil)).To(Succeed())
 			Expect(called).To(BeTrue())
 		})
 	})

--- a/pkg/reconciler/extensions.go
+++ b/pkg/reconciler/extensions.go
@@ -1,0 +1,51 @@
+package reconciler
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/operator-framework/helm-operator-plugins/pkg/extension"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type extensions []extension.ReconcilerExtension
+
+func (es extensions) forEach(f func(e extension.ReconcilerExtension) error) error {
+	var err error
+	for _, e := range es {
+		err = f(e)
+		if err != nil {
+			return err
+		}
+	}
+	return err
+}
+
+func (r *Reconciler) extBeginReconcile(ctx context.Context, reconciliationContext *extension.Context, obj *unstructured.Unstructured) error {
+	return r.extensions.forEach(func(ext extension.ReconcilerExtension) error {
+		e, ok := ext.(extension.BeginReconciliationExtension)
+		if !ok {
+			return nil
+		}
+		err := e.BeginReconcile(ctx, reconciliationContext, obj)
+		if err != nil {
+			return fmt.Errorf("extension %s failed during begin-reconcile phase: %v", ext.Name(), err)
+		}
+		return nil
+	})
+}
+
+func (r *Reconciler) extEndReconcile(ctx context.Context, reconciliationContext *extension.Context, obj *unstructured.Unstructured) error {
+	return r.extensions.forEach(func(ext extension.ReconcilerExtension) error {
+		e, ok := ext.(extension.EndReconciliationExtension)
+		if !ok {
+			return nil
+		}
+
+		err := e.EndReconcile(ctx, reconciliationContext, obj)
+		if err != nil {
+			return fmt.Errorf("extension %s failed during end-reconcile phase: %v", ext.Name(), err)
+		}
+		return nil
+	})
+}

--- a/pkg/reconciler/extensions.go
+++ b/pkg/reconciler/extensions.go
@@ -21,13 +21,13 @@ func (es extensions) forEach(f func(e extension.ReconcilerExtension) error) erro
 	return err
 }
 
-func (r *Reconciler) extBeginReconcile(ctx context.Context, reconciliationContext *extension.Context, obj *unstructured.Unstructured) error {
+func (r *Reconciler) extBeginReconcile(ctx context.Context, obj *unstructured.Unstructured) error {
 	return r.extensions.forEach(func(ext extension.ReconcilerExtension) error {
 		e, ok := ext.(extension.BeginReconciliationExtension)
 		if !ok {
 			return nil
 		}
-		err := e.BeginReconcile(ctx, reconciliationContext, obj)
+		err := e.BeginReconcile(ctx, obj)
 		if err != nil {
 			return fmt.Errorf("extension %s failed during begin-reconcile phase: %v", ext.Name(), err)
 		}
@@ -35,14 +35,14 @@ func (r *Reconciler) extBeginReconcile(ctx context.Context, reconciliationContex
 	})
 }
 
-func (r *Reconciler) extEndReconcile(ctx context.Context, reconciliationContext *extension.Context, obj *unstructured.Unstructured) error {
+func (r *Reconciler) extEndReconcile(ctx context.Context, obj *unstructured.Unstructured) error {
 	return r.extensions.forEach(func(ext extension.ReconcilerExtension) error {
 		e, ok := ext.(extension.EndReconciliationExtension)
 		if !ok {
 			return nil
 		}
 
-		err := e.EndReconcile(ctx, reconciliationContext, obj)
+		err := e.EndReconcile(ctx, obj)
 		if err != nil {
 			return fmt.Errorf("extension %s failed during end-reconcile phase: %v", ext.Name(), err)
 		}

--- a/pkg/reconciler/internal/hook/hook.go
+++ b/pkg/reconciler/internal/hook/hook.go
@@ -63,9 +63,9 @@ func (d *dependentResourceWatcher) Name() string {
 	return "internal-dependent-resource-watcher"
 }
 
-func (d *dependentResourceWatcher) EndReconcile(ctx context.Context, reconciliationContext *extension.Context, owner *unstructured.Unstructured) error {
+func (d *dependentResourceWatcher) EndReconcile(ctx context.Context, owner *unstructured.Unstructured) error {
 	log := logr.FromContextOrDiscard(ctx)
-	rel := reconciliationContext.GetHelmRelease()
+	rel := extension.HelmReleaseFromContext(ctx)
 
 	// using predefined functions for filtering events
 	dependentPredicate := predicate.DependentPredicateFuncs()

--- a/pkg/reconciler/internal/hook/hook_test.go
+++ b/pkg/reconciler/internal/hook/hook_test.go
@@ -68,18 +68,18 @@ var _ = Describe("Hook", func() {
 			})
 			It("should fail with an invalid release manifest", func() {
 				rel.Manifest = "---\nfoobar"
-				err := drw.EndReconcile(context.TODO(), &extension.Context{HelmRelease: rel}, owner)
+				err := drw.EndReconcile(extension.NewContext(context.TODO(), &extension.Context{HelmRelease: rel}), owner)
 				Expect(err).NotTo(BeNil())
 			})
 			It("should fail with unknown owner kind", func() {
-				Expect(drw.EndReconcile(context.TODO(), &extension.Context{HelmRelease: rel}, owner)).To(MatchError(&meta.NoKindMatchError{
+				Expect(drw.EndReconcile(extension.NewContext(context.TODO(), &extension.Context{HelmRelease: rel}), owner)).To(MatchError(&meta.NoKindMatchError{
 					GroupKind:        schema.GroupKind{Group: "apps", Kind: "Deployment"},
 					SearchedVersions: []string{"v1"},
 				}))
 			})
 			It("should fail with unknown dependent kind", func() {
 				rm.Add(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}, meta.RESTScopeNamespace)
-				Expect(drw.EndReconcile(context.TODO(), &extension.Context{HelmRelease: rel}, owner)).To(MatchError(&meta.NoKindMatchError{
+				Expect(drw.EndReconcile(extension.NewContext(context.TODO(), &extension.Context{HelmRelease: rel}), owner)).To(MatchError(&meta.NoKindMatchError{
 					GroupKind:        schema.GroupKind{Group: "apps", Kind: "ReplicaSet"},
 					SearchedVersions: []string{"v1"},
 				}))
@@ -109,7 +109,7 @@ var _ = Describe("Hook", func() {
 					Manifest: strings.Join([]string{clusterRole, clusterRole, rsOwnerNamespace, rsOwnerNamespace}, "---\n"),
 				}
 				drw = internalhook.NewDependentResourceWatcher(c, rm)
-				Expect(drw.EndReconcile(context.TODO(), &extension.Context{HelmRelease: rel}, owner)).To(Succeed())
+				Expect(drw.EndReconcile(extension.NewContext(context.TODO(), &extension.Context{HelmRelease: rel}), owner)).To(Succeed())
 				Expect(c.WatchCalls).To(HaveLen(2))
 				Expect(c.WatchCalls[0].Handler).To(BeAssignableToTypeOf(&handler.EnqueueRequestForOwner{}))
 				Expect(c.WatchCalls[1].Handler).To(BeAssignableToTypeOf(&handler.EnqueueRequestForOwner{}))
@@ -132,7 +132,7 @@ var _ = Describe("Hook", func() {
 						Manifest: strings.Join([]string{rsOwnerNamespace, ssOtherNamespace}, "---\n"),
 					}
 					drw = internalhook.NewDependentResourceWatcher(c, rm)
-					Expect(drw.EndReconcile(context.TODO(), &extension.Context{HelmRelease: rel}, owner)).To(Succeed())
+					Expect(drw.EndReconcile(extension.NewContext(context.TODO(), &extension.Context{HelmRelease: rel}), owner)).To(Succeed())
 					Expect(c.WatchCalls).To(HaveLen(2))
 					Expect(c.WatchCalls[0].Handler).To(BeAssignableToTypeOf(&handler.EnqueueRequestForOwner{}))
 					Expect(c.WatchCalls[1].Handler).To(BeAssignableToTypeOf(&handler.EnqueueRequestForOwner{}))
@@ -143,7 +143,7 @@ var _ = Describe("Hook", func() {
 						Manifest: strings.Join([]string{clusterRole, clusterRoleBinding}, "---\n"),
 					}
 					drw = internalhook.NewDependentResourceWatcher(c, rm)
-					Expect(drw.EndReconcile(context.TODO(), &extension.Context{HelmRelease: rel}, owner)).To(Succeed())
+					Expect(drw.EndReconcile(extension.NewContext(context.TODO(), &extension.Context{HelmRelease: rel}), owner)).To(Succeed())
 					Expect(c.WatchCalls).To(HaveLen(2))
 					Expect(c.WatchCalls[0].Handler).To(BeAssignableToTypeOf(&handler.EnqueueRequestForOwner{}))
 					Expect(c.WatchCalls[1].Handler).To(BeAssignableToTypeOf(&handler.EnqueueRequestForOwner{}))
@@ -153,7 +153,7 @@ var _ = Describe("Hook", func() {
 						Manifest: strings.Join([]string{rsOwnerNamespaceWithKeep, ssOtherNamespaceWithKeep, clusterRoleWithKeep, clusterRoleBindingWithKeep}, "---\n"),
 					}
 					drw = internalhook.NewDependentResourceWatcher(c, rm)
-					Expect(drw.EndReconcile(context.TODO(), &extension.Context{HelmRelease: rel}, owner)).To(Succeed())
+					Expect(drw.EndReconcile(extension.NewContext(context.TODO(), &extension.Context{HelmRelease: rel}), owner)).To(Succeed())
 					Expect(c.WatchCalls).To(HaveLen(4))
 					Expect(c.WatchCalls[0].Handler).To(BeAssignableToTypeOf(&sdkhandler.EnqueueRequestForAnnotation{}))
 					Expect(c.WatchCalls[1].Handler).To(BeAssignableToTypeOf(&sdkhandler.EnqueueRequestForAnnotation{}))
@@ -180,7 +180,7 @@ var _ = Describe("Hook", func() {
 						Manifest: strings.Join([]string{rsOwnerNamespace}, "---\n"),
 					}
 					drw = internalhook.NewDependentResourceWatcher(c, rm)
-					Expect(drw.EndReconcile(context.TODO(), &extension.Context{HelmRelease: rel}, owner)).To(Succeed())
+					Expect(drw.EndReconcile(extension.NewContext(context.TODO(), &extension.Context{HelmRelease: rel}), owner)).To(Succeed())
 					Expect(c.WatchCalls).To(HaveLen(1))
 					Expect(c.WatchCalls[0].Handler).To(BeAssignableToTypeOf(&handler.EnqueueRequestForOwner{}))
 				})
@@ -189,7 +189,7 @@ var _ = Describe("Hook", func() {
 						Manifest: strings.Join([]string{clusterRole}, "---\n"),
 					}
 					drw = internalhook.NewDependentResourceWatcher(c, rm)
-					Expect(drw.EndReconcile(context.TODO(), &extension.Context{HelmRelease: rel}, owner)).To(Succeed())
+					Expect(drw.EndReconcile(extension.NewContext(context.TODO(), &extension.Context{HelmRelease: rel}), owner)).To(Succeed())
 					Expect(c.WatchCalls).To(HaveLen(1))
 					Expect(c.WatchCalls[0].Handler).To(BeAssignableToTypeOf(&sdkhandler.EnqueueRequestForAnnotation{}))
 				})
@@ -198,7 +198,7 @@ var _ = Describe("Hook", func() {
 						Manifest: strings.Join([]string{ssOtherNamespace}, "---\n"),
 					}
 					drw = internalhook.NewDependentResourceWatcher(c, rm)
-					Expect(drw.EndReconcile(context.TODO(), &extension.Context{HelmRelease: rel}, owner)).To(Succeed())
+					Expect(drw.EndReconcile(extension.NewContext(context.TODO(), &extension.Context{HelmRelease: rel}), owner)).To(Succeed())
 					Expect(c.WatchCalls).To(HaveLen(1))
 					Expect(c.WatchCalls[0].Handler).To(BeAssignableToTypeOf(&sdkhandler.EnqueueRequestForAnnotation{}))
 				})
@@ -207,7 +207,7 @@ var _ = Describe("Hook", func() {
 						Manifest: strings.Join([]string{rsOwnerNamespaceWithKeep, ssOtherNamespaceWithKeep, clusterRoleWithKeep}, "---\n"),
 					}
 					drw = internalhook.NewDependentResourceWatcher(c, rm)
-					Expect(drw.EndReconcile(context.TODO(), &extension.Context{HelmRelease: rel}, owner)).To(Succeed())
+					Expect(drw.EndReconcile(extension.NewContext(context.TODO(), &extension.Context{HelmRelease: rel}), owner)).To(Succeed())
 					Expect(c.WatchCalls).To(HaveLen(3))
 					Expect(c.WatchCalls[0].Handler).To(BeAssignableToTypeOf(&sdkhandler.EnqueueRequestForAnnotation{}))
 					Expect(c.WatchCalls[1].Handler).To(BeAssignableToTypeOf(&sdkhandler.EnqueueRequestForAnnotation{}))
@@ -218,7 +218,7 @@ var _ = Describe("Hook", func() {
 						Manifest: strings.Join([]string{replicaSetList}, "---\n"),
 					}
 					drw = internalhook.NewDependentResourceWatcher(c, rm)
-					Expect(drw.EndReconcile(context.TODO(), &extension.Context{HelmRelease: rel}, owner)).To(Succeed())
+					Expect(drw.EndReconcile(extension.NewContext(context.TODO(), &extension.Context{HelmRelease: rel}), owner)).To(Succeed())
 					Expect(c.WatchCalls).To(HaveLen(2))
 					Expect(c.WatchCalls[0].Handler).To(BeAssignableToTypeOf(&handler.EnqueueRequestForOwner{}))
 					Expect(c.WatchCalls[1].Handler).To(BeAssignableToTypeOf(&handler.EnqueueRequestForOwner{}))
@@ -228,7 +228,7 @@ var _ = Describe("Hook", func() {
 						Manifest: strings.Join([]string{errReplicaSetList}, "---\n"),
 					}
 					drw = internalhook.NewDependentResourceWatcher(c, rm)
-					err := drw.EndReconcile(context.TODO(), &extension.Context{HelmRelease: rel}, owner)
+					err := drw.EndReconcile(extension.NewContext(context.TODO(), &extension.Context{HelmRelease: rel}), owner)
 					Expect(err).To(HaveOccurred())
 				})
 			})

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -516,9 +516,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.
 	}
 	u.UpdateStatus(updater.EnsureCondition(conditions.Initialized(corev1.ConditionTrue, "", "")))
 
-	reconciliationContext := extension.Context{}
-
-	err = r.extBeginReconcile(ctx, &reconciliationContext, obj)
+	err = r.extBeginReconcile(ctx, obj)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -528,7 +526,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.
 		if err != nil {
 			return ctrl.Result{}, err
 		}
-		err = r.extEndReconcile(ctx, &reconciliationContext, obj)
+		err = r.extEndReconcile(ctx, obj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -577,10 +575,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.
 		return ctrl.Result{}, fmt.Errorf("unexpected release state: %s", state)
 	}
 
-	reconciliationContext.HelmRelease = rel
-	reconciliationContext.HelmValues = vals
+	reconciliationContext := extension.Context{HelmRelease: rel, HelmValues: vals}
+	ctx = extension.NewContext(ctx, &reconciliationContext)
 
-	err = r.extEndReconcile(ctx, &reconciliationContext, obj)
+	err = r.extEndReconcile(ctx, obj)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -348,7 +348,7 @@ var _ = Describe("Reconciler", func() {
 				Expect(WithPreHook(preHook)(r)).To(Succeed())
 				Expect(len(r.extensions)).To(Equal(nExtensions + 1))
 				hook := r.extensions[nExtensions].(extension.BeginReconciliationExtension)
-				Expect(hook.BeginReconcile(context.TODO(), nil, nil)).To(Succeed())
+				Expect(hook.BeginReconcile(context.TODO(), nil)).To(Succeed())
 				Expect(called).To(BeTrue())
 			})
 		})
@@ -363,7 +363,7 @@ var _ = Describe("Reconciler", func() {
 				Expect(WithPostHook(postHook)(r)).To(Succeed())
 				Expect(len(r.extensions)).To(Equal(nExtensions + 1))
 				hook := r.extensions[nExtensions].(extension.EndReconciliationExtension)
-				Expect(hook.EndReconcile(context.TODO(), nil, nil)).To(Succeed())
+				Expect(hook.EndReconcile(context.TODO(), nil)).To(Succeed())
 				Expect(called).To(BeTrue())
 			})
 		})
@@ -502,7 +502,7 @@ var _ = Describe("Reconciler", func() {
 				r.extensions = append(r.extensions, failingPreReconciliationExt)
 				r.extensions = append(r.extensions, succeedingPreReconciliationExt)
 
-				err := r.extBeginReconcile(ctx, nil, &unstructured.Unstructured{})
+				err := r.extBeginReconcile(ctx, &unstructured.Unstructured{})
 				Expect(err).To(HaveOccurred())
 				Expect(failingPreReconciliationExtCalled).To(BeTrue())
 				Expect(succeedingPreReconciliationExtCalled).To(BeFalse())
@@ -1432,7 +1432,7 @@ func (e *testBeginReconcileExtension) Name() string {
 	return "test-extension"
 }
 
-func (e *testBeginReconcileExtension) BeginReconcile(ctx context.Context, reconciliationContext *extension.Context, obj *unstructured.Unstructured) error {
+func (e *testBeginReconcileExtension) BeginReconcile(ctx context.Context, obj *unstructured.Unstructured) error {
 	return e.f()
 }
 


### PR DESCRIPTION
For comparison, this is essentially the same as https://github.com/operator-framework/helm-operator-plugins/pull/157 with the information passing being implemented on top of `context.Context`. 

I tend to lean towards the way it is being done in https://github.com/operator-framework/helm-operator-plugins/pull/157, but since we had discussed it this way, I am opening this draft PR as well.
@varshaprasad96 @joelanford @misberner 
