### PR TITLE
add installed release manifest to more verbose logs

### DIFF
--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -746,6 +746,12 @@ func (r *Reconciler) doInstall(actionClient helmclient.ActionInterface, u *updat
 	r.reportOverrideEvents(obj)
 
 	log.Info("Release installed", "name", rel.Name, "version", rel.Version)
+
+	// If log verbosity is higher, output Helm Release Manifest
+	if log.V(1).Enabled() {
+		fmt.Println(rel.Manifest)
+	}
+
 	return rel, nil
 }
 

--- a/pkg/watches/watches.go
+++ b/pkg/watches/watches.go
@@ -98,6 +98,11 @@ func LoadReader(reader io.Reader) ([]Watch, error) {
 			w.WatchDependentResources = &trueVal
 		}
 
+		// make sure we do not have a nil LabelSelector. Instead just make it default to empty
+		if w.Selector == nil {
+			w.Selector = &metav1.LabelSelector{}
+		}
+
 		w.OverrideValues, err = expandOverrideValues(w.OverrideValues)
 		if err != nil {
 			return nil, fmt.Errorf("failed to expand override values")


### PR DESCRIPTION
## Description of the change
When the log level is set to be more verbose when running a hybrid operator, print the installed Helm Release manifest

## Motivation for the change
resolves #14