### PR TITLE
add a nil check for Watch Selector field

### DIFF
--- a/pkg/watches/watches.go
+++ b/pkg/watches/watches.go
@@ -98,6 +98,10 @@ func LoadReader(reader io.Reader) ([]Watch, error) {
 			w.WatchDependentResources = &trueVal
 		}
 
+		if w.Selector == nil {
+			w.Selector = &metav1.LabelSelector{}
+		}
+
 		w.OverrideValues, err = expandOverrideValues(w.OverrideValues)
 		if err != nil {
 			return nil, fmt.Errorf("failed to expand override values")


### PR DESCRIPTION
## Description of the change
Adds a nil check for the `Watch.Selector` field when loading watches. If it is found to be nil, set it to an empty `LabelSelector`

## Motivation for the change
resolves #163 