### PR TITLE
log manager options

### DIFF
--- a/internal/cmd/helm-operator/run/cmd.go
+++ b/internal/cmd/helm-operator/run/cmd.go
@@ -129,12 +129,19 @@ func run(cmd *cobra.Command, f *flags.Flags) {
 	options = f.ToManagerOptions(options)
 
 	// Log manager option flags
-	log.Info("Setting manager options:",
-		"MetricsBindAddress", options.MetricsBindAddress,
-		"HealthProbeAddress", options.HealthProbeBindAddress,
-		"LeaderElection", options.LeaderElection,
-		"LeaderElectionId", options.LeaderElectionID,
-		"LeaderElectionNamespace", options.LeaderElectionNamespace)
+	// Log manager option flags
+	optionsLog := map[string]interface{}{
+		"MetricsBindAddress": options.MetricsBindAddress,
+		"HealthProbeAddress": options.HealthProbeBindAddress,
+		"LeaderElection":     options.LeaderElection,
+	}
+	if options.LeaderElectionID != "" {
+		optionsLog["LeaderElectionId"] = options.LeaderElectionID
+	}
+	if options.LeaderElectionNamespace != "" {
+		optionsLog["LeaderElectionNamespace"] = options.LeaderElectionNamespace
+	}
+	log.Info("Setting manager options", "Options", optionsLog)
 
 	if options.NewClient == nil {
 		options.NewClient = helmmgr.NewCachingClientFunc()

--- a/internal/cmd/helm-operator/run/cmd.go
+++ b/internal/cmd/helm-operator/run/cmd.go
@@ -128,6 +128,14 @@ func run(cmd *cobra.Command, f *flags.Flags) {
 	// Set default manager options
 	options = f.ToManagerOptions(options)
 
+	// Log manager option flags
+	log.Info("Setting manager options:",
+		"MetricsBindAddress", options.MetricsBindAddress,
+		"HealthProbeAddress", options.HealthProbeBindAddress,
+		"LeaderElection", options.LeaderElection,
+		"LeaderElectionId", options.LeaderElectionID,
+		"LeaderElectionNamespace", options.LeaderElectionNamespace)
+
 	if options.NewClient == nil {
 		options.NewClient = helmmgr.NewCachingClientFunc()
 	}

--- a/internal/cmd/hybrid-operator/run/cmd.go
+++ b/internal/cmd/hybrid-operator/run/cmd.go
@@ -128,12 +128,18 @@ func run(cmd *cobra.Command, f *flags.Flags) {
 	options = f.ToManagerOptions(options)
 
 	// Log manager option flags
-	log.Info("Setting manager options:",
-		"MetricsBindAddress", options.MetricsBindAddress,
-		"HealthProbeAddress", options.HealthProbeBindAddress,
-		"LeaderElection", options.LeaderElection,
-		"LeaderElectionId", options.LeaderElectionID,
-		"LeaderElectionNamespace", options.LeaderElectionNamespace)
+	optionsLog := map[string]interface{}{
+		"MetricsBindAddress": options.MetricsBindAddress,
+		"HealthProbeAddress": options.HealthProbeBindAddress,
+		"LeaderElection":     options.LeaderElection,
+	}
+	if options.LeaderElectionID != "" {
+		optionsLog["LeaderElectionId"] = options.LeaderElectionID
+	}
+	if options.LeaderElectionNamespace != "" {
+		optionsLog["LeaderElectionNamespace"] = options.LeaderElectionNamespace
+	}
+	log.Info("Setting manager options", "Options", optionsLog)
 
 	if options.NewClient == nil {
 		options.NewClient = helmmgr.NewCachingClientFunc()

--- a/internal/cmd/hybrid-operator/run/cmd.go
+++ b/internal/cmd/hybrid-operator/run/cmd.go
@@ -127,6 +127,14 @@ func run(cmd *cobra.Command, f *flags.Flags) {
 	// Set default manager options
 	options = f.ToManagerOptions(options)
 
+	// Log manager option flags
+	log.Info("Setting manager options:",
+		"MetricsBindAddress", options.MetricsBindAddress,
+		"HealthProbeAddress", options.HealthProbeBindAddress,
+		"LeaderElection", options.LeaderElection,
+		"LeaderElectionId", options.LeaderElectionID,
+		"LeaderElectionNamespace", options.LeaderElectionNamespace)
+
 	if options.NewClient == nil {
 		options.NewClient = helmmgr.NewCachingClientFunc()
 	}


### PR DESCRIPTION
## Description of the change
Add logging of the manager options for both the helm and hybrid operator commands

## Motivation for the change
resolves #24