### PR TITLE
patch makefile for envtest 1.24

### DIFF
--- a/pkg/plugins/hybrid/v1alpha/scaffolds/internal/templates/makefile.go
+++ b/pkg/plugins/hybrid/v1alpha/scaffolds/internal/templates/makefile.go
@@ -77,7 +77,7 @@ IMG ?= {{ .Image }}
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.22
+ENVTEST_K8S_VERSION = 1.24
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))


### PR DESCRIPTION
Update the hybrid Makefile scaffold to use envtest version 1.24 instead of 1.22