### PR TITLE
bump go to 1.18 in scaffolded Dockerfile

### DIFF
--- a/pkg/plugins/hybrid/v1alpha/scaffolds/internal/templates/dockerfile.go
+++ b/pkg/plugins/hybrid/v1alpha/scaffolds/internal/templates/dockerfile.go
@@ -41,7 +41,7 @@ func (f *Dockerfile) SetTemplateDefaults() error {
 // `api/` and `controller/` they would have to be added.
 
 const dockerfileTemplate = `# Build the manager binary
-FROM golang:1.17 as builder
+FROM golang:1.18 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/testdata/hybrid/memcached-operator/Dockerfile
+++ b/testdata/hybrid/memcached-operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.17 as builder
+FROM golang:1.18 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
We bumped Go version to 1.18 but missed the Dockerfile. This PR updates the Dockerfile to use Go 1.18.