### PR TITLE
Make a copy of rest.Config provided to k8s.io/cli-runtime.

### DIFF
--- a/pkg/client/restclientgetter.go
+++ b/pkg/client/restclientgetter.go
@@ -48,7 +48,7 @@ type restClientGetter struct {
 }
 
 func (c *restClientGetter) ToRESTConfig() (*rest.Config, error) {
-	return c.restConfig, nil
+	return rest.CopyConfig(c.restConfig), nil
 }
 
 func (c *restClientGetter) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {


### PR DESCRIPTION
Fixes: #189 