### PR TITLE
Add various functional options to ActionConfigGetter and ActionClientGetter constructors

### DIFF
--- a/pkg/client/actionconfig_test.go
+++ b/pkg/client/actionconfig_test.go
@@ -17,9 +17,22 @@ limitations under the License.
 package client
 
 import (
+	"bytes"
+	"context"
+	"fmt"
+
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/kube"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/cli-runtime/pkg/resource"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
@@ -28,10 +41,127 @@ import (
 
 var _ = Describe("ActionConfig", func() {
 	var _ = Describe("NewActionConfigGetter", func() {
+		var rm meta.RESTMapper
+
+		BeforeEach(func() {
+			var err error
+			rm, err = apiutil.NewDiscoveryRESTMapper(cfg)
+			Expect(err).To(BeNil())
+		})
+
 		It("should return a valid ActionConfigGetter", func() {
 			acg, err := NewActionConfigGetter(cfg, nil, logr.Discard())
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(acg).NotTo(BeNil())
+		})
+
+		When("passing options", func() {
+			var (
+				obj client.Object
+				cl  client.Client
+			)
+
+			BeforeEach(func() {
+				obj = testutil.BuildTestCR(gvk)
+
+				var err error
+				cl, err = client.New(cfg, client.Options{Scheme: clientgoscheme.Scheme})
+				Expect(err).To(BeNil())
+			})
+
+			It("should use a custom client namespace", func() {
+				clientNs := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("client-%s", rand.String(8))}}
+				clientNsMapper := func(_ client.Object) (string, error) { return clientNs.Name, nil }
+				acg, err := NewActionConfigGetter(cfg, rm, logr.Discard(),
+					ClientNamespaceMapper(clientNsMapper),
+				)
+				Expect(err).To(BeNil())
+				ac, err := acg.ActionConfigFor(obj)
+				Expect(err).To(BeNil())
+				Expect(ac.KubeClient.(*kube.Client).Namespace).To(Equal(clientNs.Name))
+				Expect(ac.RESTClientGetter.(*namespacedRCG).namespaceConfig.Namespace()).To(Equal(clientNs.Name))
+				resources, err := ac.KubeClient.Build(bytes.NewBufferString(`---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa`), false)
+				Expect(err).To(BeNil())
+				Expect(resources.Visit(func(info *resource.Info, err error) error {
+					Expect(err).To(BeNil())
+					Expect(info.Namespace).To(Equal(clientNs.Name))
+					return nil
+				})).To(Succeed())
+			})
+
+			It("should use a custom storage namespace", func() {
+				storageNs := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("storage-%s", rand.String(8))}}
+				storageNsMapper := func(_ client.Object) (string, error) { return storageNs.Name, nil }
+				acg, err := NewActionConfigGetter(cfg, rm, logr.Discard(),
+					StorageNamespaceMapper(storageNsMapper),
+				)
+				Expect(err).To(BeNil())
+
+				ac, err := acg.ActionConfigFor(obj)
+				Expect(err).To(BeNil())
+
+				By("Creating the storage namespace")
+				Expect(cl.Create(context.Background(), storageNs)).To(Succeed())
+
+				By("Installing a release")
+				i := action.NewInstall(ac)
+				i.ReleaseName = fmt.Sprintf("release-name-%s", rand.String(8))
+				i.Namespace = obj.GetNamespace()
+				rel, err := i.Run(&chrt, nil)
+				Expect(err).To(BeNil())
+				Expect(rel.Namespace).To(Equal(obj.GetNamespace()))
+
+				By("Verifying the release secret is created in the storage namespace")
+				secretKey := types.NamespacedName{
+					Namespace: storageNs.Name,
+					Name:      fmt.Sprintf("sh.helm.release.v1.%s.v1", i.ReleaseName),
+				}
+				secret := &corev1.Secret{}
+				Expect(cl.Get(context.Background(), secretKey, secret)).To(Succeed())
+				Expect(secret.OwnerReferences).To(HaveLen(1))
+
+				By("Uninstalling the release")
+				_, err = action.NewUninstall(ac).Run(i.ReleaseName)
+				Expect(err).To(BeNil())
+
+				By("Deleting the storage namespace")
+				Expect(cl.Delete(context.Background(), storageNs)).To(Succeed())
+			})
+
+			It("should disable storage owner ref injection", func() {
+				acg, err := NewActionConfigGetter(cfg, rm, logr.Discard(),
+					DisableStorageOwnerRefInjection(true),
+				)
+				Expect(err).To(BeNil())
+
+				ac, err := acg.ActionConfigFor(obj)
+				Expect(err).To(BeNil())
+
+				By("Installing a release")
+				i := action.NewInstall(ac)
+				i.ReleaseName = fmt.Sprintf("release-name-%s", rand.String(8))
+				i.Namespace = obj.GetNamespace()
+				rel, err := i.Run(&chrt, nil)
+				Expect(err).To(BeNil())
+				Expect(rel.Namespace).To(Equal(obj.GetNamespace()))
+
+				By("Verifying the release secret has no owner references")
+				secretKey := types.NamespacedName{
+					Namespace: obj.GetNamespace(),
+					Name:      fmt.Sprintf("sh.helm.release.v1.%s.v1", i.ReleaseName),
+				}
+				secret := &corev1.Secret{}
+				Expect(cl.Get(context.Background(), secretKey, secret)).To(Succeed())
+				Expect(secret.OwnerReferences).To(HaveLen(0))
+
+				By("Uninstalling the release")
+				_, err = action.NewUninstall(ac).Run(i.ReleaseName)
+				Expect(err).To(BeNil())
+			})
 		})
 	})
 

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -881,7 +881,10 @@ func (r *Reconciler) addDefaults(mgr ctrl.Manager, controllerName string) error 
 		if err != nil {
 			return fmt.Errorf("creating action config getter: %w", err)
 		}
-		r.actionClientGetter = helmclient.NewActionClientGetter(actionConfigGetter)
+		r.actionClientGetter, err = helmclient.NewActionClientGetter(actionConfigGetter)
+		if err != nil {
+			return fmt.Errorf("creating action client getter: %v", err)
+		}
 	}
 	if r.eventRecorder == nil {
 		r.eventRecorder = mgr.GetEventRecorderFor(controllerName)


### PR DESCRIPTION
This PR adds

In `ActionConfigGetter` constructor:
- Use a custom mapper in the action config getter to map an object to the helm client's configured namespace
- Use a custom mapper in the action config getter to map an object to the namespace where the release secret is stored
- Configure whether or not the release secret will have an owner reference to the object for which the `action.Configuration` is generated.

These are useful to give users of this library more control to decouple release storage from install namespace.

In `ActionClientGetter` constructur:
- Append custom default functional options used to create `action.Get`, `action.Install`, `action.Upgrade`, `action.Uninstall`, and `action.Rollback`.

These are useful to give users of this library the ability to customize how the various methods of the default `ActionInterface` interact with Helm. One example use case here is setting `Wait` to `true` for uninstall/rollback to ensure that subsequent reconciliations do not encounter conflicting objects that are still being deleted.

Signed-off-by: Joe Lanford <joe.lanford@gmail.com>