### PR TITLE
Fix memory leak due to misuse of K8s clients

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,6 @@ require (
 	k8s.io/apimachinery v0.24.2
 	k8s.io/cli-runtime v0.24.2
 	k8s.io/client-go v0.24.2
-	k8s.io/kubectl v0.24.2
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
 	sigs.k8s.io/controller-runtime v0.12.2
 	sigs.k8s.io/kubebuilder/v3 v3.6.0
@@ -178,6 +177,7 @@ require (
 	k8s.io/component-base v0.24.2 // indirect
 	k8s.io/klog/v2 v2.60.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220627174259-011e075b9cb8 // indirect
+	k8s.io/kubectl v0.24.2 // indirect
 	oras.land/oras-go v1.2.0 // indirect
 	sigs.k8s.io/controller-tools v0.9.2 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect

--- a/pkg/client/actionclient_test.go
+++ b/pkg/client/actionclient_test.go
@@ -59,7 +59,8 @@ var _ = Describe("ActionClient", func() {
 	})
 	var _ = Describe("NewActionClientGetter", func() {
 		It("should return a valid ActionConfigGetter", func() {
-			actionConfigGetter := NewActionConfigGetter(cfg, rm, logr.Discard())
+			actionConfigGetter, err := NewActionConfigGetter(cfg, rm, logr.Discard())
+			Expect(err).ShouldNot(HaveOccurred())
 			Expect(NewActionClientGetter(actionConfigGetter)).NotTo(BeNil())
 		})
 	})
@@ -85,7 +86,9 @@ var _ = Describe("ActionClient", func() {
 			obj = testutil.BuildTestCR(gvk)
 		})
 		It("should return a valid ActionClient", func() {
-			acg := NewActionClientGetter(NewActionConfigGetter(cfg, rm, logr.Discard()))
+			actionConfGetter, err := NewActionConfigGetter(cfg, rm, logr.Discard())
+			Expect(err).ShouldNot(HaveOccurred())
+			acg := NewActionClientGetter(actionConfGetter)
 			ac, err := acg.ActionClientFor(obj)
 			Expect(err).To(BeNil())
 			Expect(ac).NotTo(BeNil())
@@ -102,8 +105,8 @@ var _ = Describe("ActionClient", func() {
 		BeforeEach(func() {
 			obj = testutil.BuildTestCR(gvk)
 
-			var err error
-			actionConfigGetter := NewActionConfigGetter(cfg, rm, logr.Discard())
+			actionConfigGetter, err := NewActionConfigGetter(cfg, rm, logr.Discard())
+			Expect(err).ShouldNot(HaveOccurred())
 			acg := NewActionClientGetter(actionConfigGetter)
 			ac, err = acg.ActionClientFor(obj)
 			Expect(err).To(BeNil())

--- a/pkg/client/actionconfig.go
+++ b/pkg/client/actionconfig.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/client-go/kubernetes"
+
 	"github.com/go-logr/logr"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/kube"
@@ -30,7 +32,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
-	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -38,64 +39,61 @@ type ActionConfigGetter interface {
 	ActionConfigFor(obj client.Object) (*action.Configuration, error)
 }
 
-func NewActionConfigGetter(cfg *rest.Config, rm meta.RESTMapper, log logr.Logger) ActionConfigGetter {
-	return &actionConfigGetter{
-		cfg:        cfg,
-		restMapper: rm,
-		log:        log,
+func NewActionConfigGetter(cfg *rest.Config, rm meta.RESTMapper, log logr.Logger) (ActionConfigGetter, error) {
+	rcg := newRESTClientGetter(cfg, rm, "")
+	// Setup the debug log function that Helm will use
+	debugLog := func(format string, v ...interface{}) {
+		if log.GetSink() != nil {
+			log.V(1).Info(fmt.Sprintf(format, v...))
+		}
 	}
+
+	kc := kube.New(rcg)
+	kc.Log = debugLog
+
+	kcs, err := kc.Factory.KubernetesClientSet()
+	if err != nil {
+		return nil, fmt.Errorf("creating kubernetes client set: %w", err)
+	}
+
+	return &actionConfigGetter{
+		kubeClient:       kc,
+		kubeClientSet:    kcs,
+		debugLog:         debugLog,
+		restClientGetter: rcg.restClientGetter,
+	}, nil
 }
 
 var _ ActionConfigGetter = &actionConfigGetter{}
 
 type actionConfigGetter struct {
-	cfg        *rest.Config
-	restMapper meta.RESTMapper
-	log        logr.Logger
+	kubeClient       *kube.Client
+	kubeClientSet    kubernetes.Interface
+	debugLog         func(string, ...interface{})
+	restClientGetter *restClientGetter
 }
 
 func (acg *actionConfigGetter) ActionConfigFor(obj client.Object) (*action.Configuration, error) {
-	// Create a RESTClientGetter
-	rcg := newRESTClientGetter(acg.cfg, acg.restMapper, obj.GetNamespace())
-
-	// Setup the debug log function that Helm will use
-	debugLog := func(format string, v ...interface{}) {
-		if acg.log.GetSink() != nil {
-			acg.log.V(1).Info(fmt.Sprintf(format, v...))
-		}
-	}
-
-	// Create a client that helm will use to manage release resources.
-	// The passed object is used as an owner reference on every
-	// object the client creates.
-	kc := kube.New(rcg)
-	kc.Log = debugLog
-
-	// Create the Kubernetes Secrets client. The passed object is
-	// also used as an owner reference in the release secrets
-	// created by this client.
-	kcs, err := cmdutil.NewFactory(rcg).KubernetesClientSet()
-	if err != nil {
-		return nil, err
-	}
-
 	ownerRef := metav1.NewControllerRef(obj, obj.GetObjectKind().GroupVersionKind())
 	d := driver.NewSecrets(&ownerRefSecretClient{
-		SecretInterface: kcs.CoreV1().Secrets(obj.GetNamespace()),
+		SecretInterface: acg.kubeClientSet.CoreV1().Secrets(obj.GetNamespace()),
 		refs:            []metav1.OwnerReference{*ownerRef},
 	})
 
 	// Also, use the debug log for the storage driver
-	d.Log = debugLog
+	d.Log = acg.debugLog
 
 	// Initialize the storage backend
 	s := storage.Init(d)
 
+	kubeClient := *acg.kubeClient
+	kubeClient.Namespace = obj.GetNamespace()
+
 	return &action.Configuration{
-		RESTClientGetter: rcg,
+		RESTClientGetter: acg.restClientGetter.ForNamespace(obj.GetNamespace()),
 		Releases:         s,
-		KubeClient:       kc,
-		Log:              debugLog,
+		KubeClient:       &kubeClient,
+		Log:              acg.debugLog,
 	}, nil
 }
 

--- a/pkg/client/actionconfig_test.go
+++ b/pkg/client/actionconfig_test.go
@@ -29,7 +29,9 @@ import (
 var _ = Describe("ActionConfig", func() {
 	var _ = Describe("NewActionConfigGetter", func() {
 		It("should return a valid ActionConfigGetter", func() {
-			Expect(NewActionConfigGetter(nil, nil, logr.Discard())).NotTo(BeNil())
+			acg, err := NewActionConfigGetter(cfg, nil, logr.Discard())
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(acg).NotTo(BeNil())
 		})
 	})
 
@@ -42,7 +44,8 @@ var _ = Describe("ActionConfig", func() {
 			rm, err := apiutil.NewDiscoveryRESTMapper(cfg)
 			Expect(err).To(BeNil())
 
-			acg := NewActionConfigGetter(cfg, rm, logr.Discard())
+			acg, err := NewActionConfigGetter(cfg, rm, logr.Discard())
+			Expect(err).ShouldNot(HaveOccurred())
 			ac, err := acg.ActionConfigFor(obj)
 			Expect(err).To(BeNil())
 			Expect(ac).NotTo(BeNil())

--- a/pkg/client/restclientgetter.go
+++ b/pkg/client/restclientgetter.go
@@ -28,20 +28,19 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
-var _ genericclioptions.RESTClientGetter = &restClientGetter{}
-
-func newRESTClientGetter(cfg *rest.Config, rm meta.RESTMapper, ns string) genericclioptions.RESTClientGetter {
-	return &restClientGetter{
-		restConfig:      cfg,
-		restMapper:      rm,
-		namespaceConfig: &namespaceClientConfig{ns},
+func newRESTClientGetter(cfg *rest.Config, rm meta.RESTMapper, ns string) *namespacedRCG {
+	return &namespacedRCG{
+		restClientGetter: &restClientGetter{
+			restConfig: cfg,
+			restMapper: rm,
+		},
+		namespaceConfig: namespaceClientConfig{ns},
 	}
 }
 
 type restClientGetter struct {
-	restConfig      *rest.Config
-	restMapper      meta.RESTMapper
-	namespaceConfig clientcmd.ClientConfig
+	restConfig *rest.Config
+	restMapper meta.RESTMapper
 
 	setupDiscoveryClient  sync.Once
 	cachedDiscoveryClient discovery.CachedDiscoveryInterface
@@ -73,7 +72,21 @@ func (c *restClientGetter) ToRESTMapper() (meta.RESTMapper, error) {
 	return c.restMapper, nil
 }
 
-func (c *restClientGetter) ToRawKubeConfigLoader() clientcmd.ClientConfig {
+func (c *restClientGetter) ForNamespace(ns string) genericclioptions.RESTClientGetter {
+	return &namespacedRCG{
+		restClientGetter: c,
+		namespaceConfig:  namespaceClientConfig{namespace: ns},
+	}
+}
+
+var _ genericclioptions.RESTClientGetter = &namespacedRCG{}
+
+type namespacedRCG struct {
+	*restClientGetter
+	namespaceConfig namespaceClientConfig
+}
+
+func (c *namespacedRCG) ToRawKubeConfigLoader() clientcmd.ClientConfig {
 	return c.namespaceConfig
 }
 

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -135,10 +135,9 @@ var _ = Describe("Reconciler", func() {
 		})
 		var _ = Describe("WithActionClientGetter", func() {
 			It("should set the reconciler action client getter", func() {
-				cfgGetter := helmclient.NewActionConfigGetter(nil, nil, logr.Discard())
-				acg := helmclient.NewActionClientGetter(cfgGetter)
-				Expect(WithActionClientGetter(acg)(r)).To(Succeed())
-				Expect(r.actionClientGetter).To(Equal(acg))
+				fakeActionClientGetter := helmfake.NewActionClientGetter(nil, nil)
+				Expect(WithActionClientGetter(fakeActionClientGetter)(r)).To(Succeed())
+				Expect(r.actionClientGetter).To(Equal(fakeActionClientGetter))
 			})
 		})
 		var _ = Describe("WithEventRecorder", func() {
@@ -974,8 +973,8 @@ var _ = Describe("Reconciler", func() {
 						var actionConf *action.Configuration
 						BeforeEach(func() {
 							By("getting the current release and config", func() {
-								var err error
-								acg := helmclient.NewActionConfigGetter(mgr.GetConfig(), mgr.GetRESTMapper(), logr.Discard())
+								acg, err := helmclient.NewActionConfigGetter(mgr.GetConfig(), mgr.GetRESTMapper(), logr.Discard())
+								Expect(err).ShouldNot(HaveOccurred())
 								actionConf, err = acg.ActionConfigFor(obj)
 								Expect(err).To(BeNil())
 							})


### PR DESCRIPTION
When investigating high memory usage in the RHACS operator, profiling showed that most of the memory consumed by the discovery client's processing of the OpenAPI schema:
<img width="1462" alt="Screen Shot 2022-09-08 at 02 18 07" src="https://user-images.githubusercontent.com/2822367/189217334-111a6f91-63cb-403b-b899-d6969e72625e.png">
The profile seemed odd because an ever-growing amount of memory is allocated in a `sync.Once`, suggesting repeated execution.

After a debugging run, I found that the `ActionClientGetter` essentially creates:
- a `restClientGetter`, with a per-instance lazily created, cached discovery client (seems minor)
- one `k8s.io/kubectl/pkg/cmd/util.Factory` instance via the `kube.New(rcg)` call
- another `Factory` via the `cmdutil.NewFactory(rcg)` call (only used for the secrets clients)
- a `kubernetes.ClientSet` (seems minor)
for **each** reconciliation of **each** CR managed by the operator. The major impact is that each factory has its own discovery client, which is initialized again and again, because it is guarded by different instances of the `sync.Once`.

When I provoked a reconciliation failure, and thereby having the operator perform one reconciliation after the other, I could get the process memory usage to over 2GB in less than a minute.

I haven't fully figured out why garbage collection was of so little use, but I suspect it has something to do with goroutines holding references to some of the objects.



Because all that the various clients need to differ on per CR instance is the namespace, the following PR changes the code to use a _single_ rest client getter, factory, and clientset for everything, injecting the namespace in a lightweight manner when obtaining a per-CR instance action client. With this change, the memory usage hovered around 80MB, even in the above-described reconciliation failure situation.


I believe that what I found and fixed is also the culprit behind several reports of high memory usage:
- https://github.com/fluxcd/helm-operator/issues/582
- https://github.com/fluxcd/helm-operator/issues/427
- https://open.greenhost.net/stackspin/stackspin/-/issues/473
- https://groups.google.com/g/operator-framework/c/-d51fqtYjYk
