### PR TITLE
Use the non-deprecated SimpleIntervalClock fake kubeclock

### DIFF
--- a/pkg/internal/status/conditions.go
+++ b/pkg/internal/status/conditions.go
@@ -27,7 +27,7 @@ import (
 
 // clock is used to set status condition timestamps.
 // This variable makes it easier to test conditions.
-var clock kubeclock.Clock = &kubeclock.RealClock{}
+var clock kubeclock.PassiveClock = &kubeclock.RealClock{}
 
 // ConditionType is the type of the condition and is typically a CamelCased
 // word or short phrase.

--- a/pkg/internal/status/conditions_test.go
+++ b/pkg/internal/status/conditions_test.go
@@ -41,16 +41,14 @@ func init() {
 
 func initConditions(init ...Condition) Conditions {
 	// Use the same initial time for all initial conditions
-	clock = kubeclock.NewFakeClock(initTime)
+	clock = kubeclock.NewFakePassiveClock(initTime)
 	conditions := Conditions{}
 	for _, c := range init {
 		conditions.SetCondition(c)
 	}
 
 	// Use an incrementing clock for the rest of the test
-	// This is deprecated but should be fine to use for now until we have a better solution
-	// nolint
-	clock = &kubeclock.IntervalClock{
+	clock = &kubeclock.SimpleIntervalClock{
 		Time:     initTime,
 		Duration: clockInterval,
 	}


### PR DESCRIPTION
The code as well as the test only require a `PassiveClock`, i.e., a clock that only supports querying the current time, without the ability to schedule future tasks in the style of `time.After`. That allows the use of a `SimpleIntervalClock`, which is not deprecated.

Note: `IntervalClock` doesn't do anything more than `SimpleIntervalClock`, as all the methods not implemented by `SimpleIntervalClock` would just panic anyway.