### PR TITLE
Ensure finalizer is present before reconciling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.8
 	github.com/operator-framework/operator-lib v0.11.1-0.20230607132417-ecb9be488378
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.15.1
 	github.com/sergi/go-diff v1.2.0
 	github.com/sirupsen/logrus v1.9.3
@@ -129,7 +130,6 @@ require (
 	github.com/opencontainers/image-spec v1.1.0-rc2.0.20221005185240-3a7f492d3f1b // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.4.0 // indirect
 	github.com/prometheus/common v0.44.0 // indirect

--- a/pkg/reconciler/internal/updater/updater.go
+++ b/pkg/reconciler/internal/updater/updater.go
@@ -122,16 +122,6 @@ func (u *Updater) Apply(ctx context.Context, obj *unstructured.Unstructured) err
 	return nil
 }
 
-func EnsureFinalizer(finalizer string) UpdateFunc {
-	return func(obj *unstructured.Unstructured) bool {
-		if controllerutil.ContainsFinalizer(obj, finalizer) {
-			return false
-		}
-		controllerutil.AddFinalizer(obj, finalizer)
-		return true
-	}
-}
-
 func RemoveFinalizer(finalizer string) UpdateFunc {
 	return func(obj *unstructured.Unstructured) bool {
 		if !controllerutil.ContainsFinalizer(obj, finalizer) {

--- a/pkg/reconciler/internal/updater/updater_test.go
+++ b/pkg/reconciler/internal/updater/updater_test.go
@@ -59,7 +59,10 @@ var _ = Describe("Updater", func() {
 	When("the object does not exist", func() {
 		It("should fail", func() {
 			Expect(client.Delete(context.TODO(), obj)).To(Succeed())
-			u.Update(EnsureFinalizer(testFinalizer))
+			u.Update(func(u *unstructured.Unstructured) bool {
+				u.SetAnnotations(map[string]string{"foo": "bar"})
+				return true
+			})
 			err := u.Apply(context.TODO(), obj)
 			Expect(err).NotTo(BeNil())
 			Expect(apierrors.IsNotFound(err)).To(BeTrue())
@@ -68,12 +71,15 @@ var _ = Describe("Updater", func() {
 
 	When("an update is a change", func() {
 		It("should apply an update function", func() {
-			u.Update(EnsureFinalizer(testFinalizer))
+			u.Update(func(u *unstructured.Unstructured) bool {
+				u.SetAnnotations(map[string]string{"foo": "bar"})
+				return true
+			})
 			resourceVersion := obj.GetResourceVersion()
 
 			Expect(u.Apply(context.TODO(), obj)).To(Succeed())
 			Expect(client.Get(context.TODO(), types.NamespacedName{Namespace: "testNamespace", Name: "testDeployment"}, obj)).To(Succeed())
-			Expect(obj.GetFinalizers()).To(Equal([]string{testFinalizer}))
+			Expect(obj.GetAnnotations()["foo"]).To(Equal("bar"))
 			Expect(obj.GetResourceVersion()).NotTo(Equal(resourceVersion))
 		})
 
@@ -86,25 +92,6 @@ var _ = Describe("Updater", func() {
 			Expect((obj.Object["status"].(map[string]interface{}))["conditions"]).To(HaveLen(1))
 			Expect(obj.GetResourceVersion()).NotTo(Equal(resourceVersion))
 		})
-	})
-})
-
-var _ = Describe("EnsureFinalizer", func() {
-	var obj *unstructured.Unstructured
-
-	BeforeEach(func() {
-		obj = &unstructured.Unstructured{}
-	})
-
-	It("should add finalizer if not present", func() {
-		Expect(EnsureFinalizer(testFinalizer)(obj)).To(BeTrue())
-		Expect(obj.GetFinalizers()).To(Equal([]string{testFinalizer}))
-	})
-
-	It("should not add duplicate finalizer", func() {
-		obj.SetFinalizers([]string{testFinalizer})
-		Expect(EnsureFinalizer(testFinalizer)(obj)).To(BeFalse())
-		Expect(obj.GetFinalizers()).To(Equal([]string{testFinalizer}))
 	})
 })
 

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -607,8 +607,8 @@ var _ = Describe("Reconciler", func() {
 								Expect(c.Message).To(Equal(acgErr.Error()))
 							})
 
-							By("verifying the uninstall finalizer is not present on the CR", func() {
-								Expect(controllerutil.ContainsFinalizer(obj, uninstallFinalizer)).To(BeFalse())
+							By("verifying the uninstall finalizer is present on the CR", func() {
+								Expect(controllerutil.ContainsFinalizer(obj, uninstallFinalizer)).To(BeTrue())
 							})
 						})
 						It("returns an error getting the release", func() {
@@ -644,8 +644,8 @@ var _ = Describe("Reconciler", func() {
 								Expect(c.Message).To(Equal("get not implemented"))
 							})
 
-							By("verifying the uninstall finalizer is not present on the CR", func() {
-								Expect(controllerutil.ContainsFinalizer(obj, uninstallFinalizer)).To(BeFalse())
+							By("verifying the uninstall finalizer is present on the CR", func() {
+								Expect(controllerutil.ContainsFinalizer(obj, uninstallFinalizer)).To(BeTrue())
 							})
 						})
 					})
@@ -680,8 +680,8 @@ var _ = Describe("Reconciler", func() {
 								Expect(c.Message).To(ContainSubstring("error parsing index"))
 							})
 
-							By("verifying the uninstall finalizer is not present on the CR", func() {
-								Expect(controllerutil.ContainsFinalizer(obj, uninstallFinalizer)).To(BeFalse())
+							By("verifying the uninstall finalizer is present on the CR", func() {
+								Expect(controllerutil.ContainsFinalizer(obj, uninstallFinalizer)).To(BeTrue())
 							})
 						})
 					})
@@ -747,8 +747,8 @@ var _ = Describe("Reconciler", func() {
 									Expect(c.Message).To(ContainSubstring("install failed: foobar"))
 								})
 
-								By("ensuring the uninstall finalizer is not present on the CR", func() {
-									Expect(controllerutil.ContainsFinalizer(obj, uninstallFinalizer)).To(BeFalse())
+								By("verifying the uninstall finalizer is present on the CR", func() {
+									Expect(controllerutil.ContainsFinalizer(obj, uninstallFinalizer)).To(BeTrue())
 								})
 							})
 						})
@@ -928,7 +928,7 @@ var _ = Describe("Reconciler", func() {
 								Expect(objStat.Status.DeployedRelease.Manifest).To(Equal(currentRelease.Manifest))
 							})
 
-							By("verifying the uninstall finalizer is not present on the CR", func() {
+							By("verifying the uninstall finalizer is present on the CR", func() {
 								Expect(controllerutil.ContainsFinalizer(obj, uninstallFinalizer)).To(BeTrue())
 							})
 						})
@@ -967,7 +967,7 @@ var _ = Describe("Reconciler", func() {
 								Expect(objStat.Status.DeployedRelease.Manifest).To(Equal(currentRelease.Manifest))
 							})
 
-							By("verifying the uninstall finalizer is not present on the CR", func() {
+							By("verifying the uninstall finalizer is present on the CR", func() {
 								Expect(controllerutil.ContainsFinalizer(obj, uninstallFinalizer)).To(BeTrue())
 							})
 						})


### PR DESCRIPTION
The current logic will apply the finalizer to the custom resource after the first reconciliation loop (in a closure). Though, in certain circumstances, the custom resource might get deleted after the first reconciliation loop has installed the chart but before it has applied the finalizer. If the chart created any resources not in the same namespace these will be orphaned without cleanup.

By ensuring that the finalizer is present on the custom resource before proceeding, this will ensure a proper cleanup in all cases.