### PR TITLE
Allow users to inject a postrenderer

### DIFF
--- a/pkg/client/postrenderer.go
+++ b/pkg/client/postrenderer.go
@@ -20,6 +20,10 @@ import (
 	"github.com/operator-framework/helm-operator-plugins/pkg/manifestutil"
 )
 
+// PostRendererProvider is a function that returns a post-renderer for a given object.
+// obj represents the custom resource that is being reconciled.
+type PostRendererProvider func(rm meta.RESTMapper, kubeClient kube.Interface, obj client.Object) postrender.PostRenderer
+
 // WithInstallPostRenderer sets the post-renderer to use for the install.
 // It overrides any post-renderer that may already be configured or set
 // as a default.


### PR DESCRIPTION
It would be useful for us to be able to inject a per-object PostRenderer to implement a feature such as istio overlays. see https://istio.io/latest/docs/setup/additional-setup/customize-installation/#patching-the-output-manifest

We cannot use the `actionClientConfigGetter` or `actionClientGetter` with a `WithInstallOption(...)` because this method doesn't pass the `CustomResource` to the renderer at the moment of installing/upgrading/dry-running. Though, our usecase would be that each CustomResource would have configurable "patches" that would be evaluated against the manifest at the moment of reconciliation.

Example of usecase: 

https://github.com/stackrox/stackrox/blob/1fd296314419b25df5831e472e74512bd5e01e5a/operator/apis/platform/v1alpha1/central_types.go#L62C3-L62C3

https://github.com/stackrox/stackrox/blob/1fd296314419b25df5831e472e74512bd5e01e5a/operator/apis/platform/v1alpha1/overlay_types.go#L17

https://github.com/stackrox/stackrox/blob/ROX-18085-operator-overlays/operator/pkg/overlays/postrenderer.go

https://github.com/stackrox/stackrox/blob/1fd296314419b25df5831e472e74512bd5e01e5a/operator/pkg/reconciler/reconciler_factory.go#L82

