### PR TITLE
(dx): remove explicit CGO_ENABLED=0 to not block FIPS compliant builds/confusion

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,5 @@
 # Global environment variables for builds.
 env:
-  - CGO_ENABLED=0
   - GO111MODULE=on
   - GOPROXY=https://proxy.golang.org|direct
   - VERSION_PKG=github.com/operator-framework/helm-operator-plugins/internal/version

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ test-sanity: generate fix lint ## Test repo formatting, linting, etc.
 # Build manager binary
 .PHONY: build
 build:
-	CGO_ENABLED=0 mkdir -p $(BUILD_DIR) && go build $(GO_BUILD_ARGS) -o $(BUILD_DIR) ./
+	mkdir -p $(BUILD_DIR) && go build $(GO_BUILD_ARGS) -o $(BUILD_DIR) ./
 
 .PHONY: setup-lint
 setup-lint: ## Setup the lint

--- a/pkg/plugins/hybrid/v1alpha/scaffolds/internal/templates/dockerfile.go
+++ b/pkg/plugins/hybrid/v1alpha/scaffolds/internal/templates/dockerfile.go
@@ -57,7 +57,7 @@ COPY api/ api/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 
 FROM registry.access.redhat.com/ubi8/ubi-micro:8.7
 

--- a/testdata/hybrid/memcached-operator/Dockerfile
+++ b/testdata/hybrid/memcached-operator/Dockerfile
@@ -15,7 +15,7 @@ COPY api/ api/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 
 FROM registry.access.redhat.com/ubi8/ubi-micro:8.7
 


### PR DESCRIPTION
**Description**:
- Removes all `CGO_ENABLED=0` references

**Motivation**:
- We shouldn't block builds from being able to be FIPS compliant by hardcoding the CGO_ENABLED=0 setting throughout our code