### PR TITLE
fix: fix a broken method on `main` branch

### DIFF
--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -1343,7 +1343,7 @@ var _ = Describe("Reconciler", func() {
 			controllerSetupCalled = true
 			u := &unstructured.Unstructured{}
 			u.SetGroupVersionKind(additionalGVK)
-			return c.Watch(&source.Kind{Type: u}, &sdkhandler.InstrumentedEnqueueRequestForObject{})
+			return c.Watch(source.Kind(mgr.GetCache(), u), &sdkhandler.InstrumentedEnqueueRequestForObject{})
 		}
 
 		It("Registering builder setup function for reconciler works", func() {


### PR DESCRIPTION
Merging #153 broke main since it was using an plder version of controller-runtime. This commit fixes the same.