### PR TITLE
workflows: don't process all branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - '**'
+      - 'main'
   pull_request:
     branches: [ main ]
 
@@ -40,7 +40,7 @@ jobs:
 
     - name: Test
       run: make test
-    
+
     - name: Test Sanity
       run: make test-sanity
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy
 on:
   push:
     branches:
-      - '**'
+      - 'main'
     tags:
       - 'v*'
   pull_request:
@@ -24,7 +24,7 @@ jobs:
       run: .ci/gpg/create-keyring.sh
       env:
         GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
-        
+
     - name: Install Go
       uses: actions/setup-go@v4
       with:


### PR DESCRIPTION
In the deploy workflow, using a push branch config of ** results in it trying to gpg init for branches created by dependabot or anyone/anything else. This is not what we want - we want those covered by pull request events.

Change the config to only handle pushes to main (and continue to handle all tags and all PRs).

Also adjust the ci workflow similarly.