### PR TITLE
Tweak CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,32 +9,17 @@ on:
     branches: [ main ]
 
 jobs:
-
   test:
     name: Test
     runs-on: ubuntu-latest
     steps:
-
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
         go-version-file: "go.mod"
-      id: go
-
-    - name: Cache go module cache
-      id: cache-go-mod
-      uses: actions/cache@v3
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-
-    - name: Get dependencies
-      run: go mod download
 
     - name: check
       run: make fix
@@ -45,15 +30,15 @@ jobs:
     - name: Test Sanity
       run: make test-sanity
 
-    - uses: shogo82148/actions-goveralls@v1
+    - uses: codecov/codecov-action@v3
       with:
-        path-to-profile: cover.out
+        files: cover.out
+        functionalities: fixes
 
   lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
 
@@ -61,7 +46,6 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version-file: "go.mod"
-      id: go
 
     - name: Lint
       uses: golangci/golangci-lint-action@v3
@@ -73,7 +57,6 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
       with:
@@ -83,7 +66,6 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version-file: "go.mod"
-      id: go
 
     - name: Run go-apidiff
       uses: joelanford/go-apidiff@main


### PR DESCRIPTION
Use setup-go's built in mod caching instead of doing it by hand.

Remove go mod download step.

Switch to codecov's coveralls action.