### PR TITLE
[Add] Allow specifying helm secret namespace for cluster scope objects

### DIFF
--- a/pkg/client/actionclient_test.go
+++ b/pkg/client/actionclient_test.go
@@ -59,7 +59,8 @@ const mockTestDesc = "Test Description"
 
 var _ = Describe("ActionClient", func() {
 	var (
-		rm meta.RESTMapper
+		rm  meta.RESTMapper
+		sch *runtime.Scheme
 	)
 	BeforeEach(func() {
 		var err error
@@ -69,10 +70,12 @@ var _ = Describe("ActionClient", func() {
 
 		rm, err = apiutil.NewDynamicRESTMapper(cfg, httpClient)
 		Expect(err).ToNot(HaveOccurred())
+
+		sch = runtime.NewScheme()
 	})
 	var _ = Describe("NewActionClientGetter", func() {
 		It("should return a valid ActionConfigGetter", func() {
-			actionConfigGetter, err := NewActionConfigGetter(cfg, rm)
+			actionConfigGetter, err := NewActionConfigGetter(cfg, rm, sch)
 			Expect(err).ShouldNot(HaveOccurred())
 			acg, err := NewActionClientGetter(actionConfigGetter)
 			Expect(err).ToNot(HaveOccurred())
@@ -89,7 +92,7 @@ var _ = Describe("ActionClient", func() {
 			)
 			BeforeEach(func() {
 				var err error
-				actionConfigGetter, err = NewActionConfigGetter(cfg, rm)
+				actionConfigGetter, err = NewActionConfigGetter(cfg, rm, sch)
 				Expect(err).ShouldNot(HaveOccurred())
 				dc, err := discovery.NewDiscoveryClientForConfig(cfg)
 				Expect(err).ShouldNot(HaveOccurred())
@@ -310,7 +313,7 @@ var _ = Describe("ActionClient", func() {
 			obj = testutil.BuildTestCR(gvk)
 		})
 		It("should return a valid ActionClient", func() {
-			actionConfGetter, err := NewActionConfigGetter(cfg, rm)
+			actionConfGetter, err := NewActionConfigGetter(cfg, rm, sch)
 			Expect(err).ShouldNot(HaveOccurred())
 			acg, err := NewActionClientGetter(actionConfGetter)
 			Expect(err).ToNot(HaveOccurred())
@@ -330,7 +333,7 @@ var _ = Describe("ActionClient", func() {
 		BeforeEach(func() {
 			obj = testutil.BuildTestCR(gvk)
 
-			actionConfigGetter, err := NewActionConfigGetter(cfg, rm)
+			actionConfigGetter, err := NewActionConfigGetter(cfg, rm, sch)
 			Expect(err).ShouldNot(HaveOccurred())
 			acg, err := NewActionClientGetter(actionConfigGetter)
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -917,7 +917,7 @@ func (r *Reconciler) addDefaults(mgr ctrl.Manager, controllerName string) error 
 		r.log = ctrl.Log.WithName("controllers").WithName("Helm")
 	}
 	if r.actionClientGetter == nil {
-		actionConfigGetter, err := helmclient.NewActionConfigGetter(mgr.GetConfig(), mgr.GetRESTMapper())
+		actionConfigGetter, err := helmclient.NewActionConfigGetter(mgr.GetConfig(), mgr.GetRESTMapper(), mgr.GetScheme())
 		if err != nil {
 			return fmt.Errorf("creating action config getter: %w", err)
 		}

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -977,7 +977,7 @@ var _ = Describe("Reconciler", func() {
 						var actionConf *action.Configuration
 						BeforeEach(func() {
 							By("getting the current release and config", func() {
-								acg, err := helmclient.NewActionConfigGetter(mgr.GetConfig(), mgr.GetRESTMapper())
+								acg, err := helmclient.NewActionConfigGetter(mgr.GetConfig(), mgr.GetRESTMapper(), mgr.GetScheme())
 								Expect(err).ShouldNot(HaveOccurred())
 								actionConf, err = acg.ActionConfigFor(ctx, obj)
 								Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Currently, the helm secret namespace is taken from the namespace of the object which is being passed to `ActionClientFor`. When the action client is created for cluster scoped objects, the namespace has to explicitly set in their metadata. This PR introduces an option to specify the namespace through the context instead.