### PR TITLE
add ability to configure and run preflight checks during install, upgrade, and uninstall operations

### DIFF
--- a/pkg/client/actionclient.go
+++ b/pkg/client/actionclient.go
@@ -148,25 +148,24 @@ const (
 type PreflightFunc func(string, *release.Release) error
 
 func NewPreflightFunc(name string, pf PreflightFunc) Preflight {
-    return &preflightFuncImpl{
-        preflightFunc: pf,
-        name: name,
-    }
+	return &preflightFuncImpl{
+		preflightFunc: pf,
+		name:          name,
+	}
 }
 
 type preflightFuncImpl struct {
-    preflightFunc PreflightFunc
-    name string
+	preflightFunc PreflightFunc
+	name          string
 }
 
 func (pfi *preflightFuncImpl) Run(operation string, rel *release.Release) error {
-    return pfi.preflightFunc(operation, rel)
+	return pfi.preflightFunc(operation, rel)
 }
 
 func (pfi *preflightFuncImpl) Name() string {
-    return pfi.name
+	return pfi.name
 }
-
 
 type actionClientGetter struct {
 	acg ActionConfigGetter

--- a/pkg/client/actionclient_test.go
+++ b/pkg/client/actionclient_test.go
@@ -387,10 +387,10 @@ var _ = Describe("ActionClient", func() {
 					})
 				})
 				When("preflight checks are configured for install operation", func() {
-                    AfterEach(func() {
-                        // Reset preflights
-                        ac.(*actionClient).preflights = []Preflight{}
-                    })
+					AfterEach(func() {
+						// Reset preflights
+						ac.(*actionClient).preflights = []Preflight{}
+					})
 					It("should fail if preflight checks fail during install", func() {
 						ac.(*actionClient).preflights = []Preflight{
 							NewPreflightFunc("installFail", func(_ string, _ *release.Release) error {
@@ -535,9 +535,9 @@ var _ = Describe("ActionClient", func() {
 					})
 				})
 				When("preflight checks are configured for upgrade operation", func() {
-                    AfterEach(func() {
-                        ac.(*actionClient).preflights = []Preflight{}
-                    })
+					AfterEach(func() {
+						ac.(*actionClient).preflights = []Preflight{}
+					})
 					It("should fail if preflight checks fail during upgrade", func() {
 						ac.(*actionClient).preflights = []Preflight{
 							NewPreflightFunc("upgradeFail", func(_ string, _ *release.Release) error {
@@ -593,9 +593,9 @@ var _ = Describe("ActionClient", func() {
 					})
 				})
 				When("preflight checks are configured for uninstall operation", func() {
-                    AfterEach(func() {
-                        ac.(*actionClient).preflights = []Preflight{}
-                    })
+					AfterEach(func() {
+						ac.(*actionClient).preflights = []Preflight{}
+					})
 					It("should fail if preflight checks fail during uninstall", func() {
 						ac.(*actionClient).preflights = []Preflight{
 							NewPreflightFunc("uninstallFail", func(_ string, _ *release.Release) error {


### PR DESCRIPTION
**Description**:
- Adds a new `Preflight` interface and ability to configure a slice of `Preflight`s to run during the `actionClient` install, upgrade, and uninstall operations.
- Updates `actionClient` unit tests to test the preflight check implementation

**Motivation**:
- https://github.com/operator-framework/operator-controller/issues/741