### PR TITLE
reconciler: use server-side dry-run to generate candidate upgrade manifest

### DIFF
--- a/pkg/client/postrenderer_test.go
+++ b/pkg/client/postrenderer_test.go
@@ -206,6 +206,7 @@ func getTestManifest() string {
 	testChart := testutil.MustLoadChart("../../pkg/internal/testdata/test-chart-1.2.0.tgz")
 	i := action.NewInstall(&action.Configuration{})
 	i.DryRun = true
+	i.DryRunOption = "client"
 	i.Replace = true
 	i.ReleaseName = "release-name"
 	i.ClientOnly = true

--- a/pkg/plugins/helm/v1/scaffolds/internal/templates/config/rbac/manager_role.go
+++ b/pkg/plugins/helm/v1/scaffolds/internal/templates/config/rbac/manager_role.go
@@ -349,6 +349,7 @@ func generateRoleRules(dc roleDiscoveryInterface, chart *chart.Chart) ([]rbacv1.
 func getDefaultManifests(c *chart.Chart) ([]releaseutil.Manifest, error) {
 	install := action.NewInstall(&action.Configuration{})
 	install.DryRun = true
+	install.DryRunOption = "client"
 	install.ReleaseName = "release-name"
 	install.Replace = true
 	install.ClientOnly = true

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -758,6 +758,7 @@ func (r *Reconciler) getReleaseState(client helmclient.ActionInterface, obj meta
 	}
 	opts = append(opts, func(u *action.Upgrade) error {
 		u.DryRun = true
+		u.DryRunOption = "server"
 		return nil
 	})
 	specRelease, err := client.Upgrade(obj.GetName(), obj.GetNamespace(), r.chrt, vals, opts...)


### PR DESCRIPTION
Closes #209 