### PR TITLE
Fix codecov-action params

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,8 @@ jobs:
 
     - uses: codecov/codecov-action@v4
       with:
+        disable_search: true
         files: cover.out
-        functionalities: fixes
 
   lint:
     name: Lint


### PR DESCRIPTION
* `functionalities` param is no longer exist. It was used to enable file fixes to ignore common lines from coverage. This feature is now seems to be on by default.

* Adding `disable_search` because we do not need for the codecov action to search for coverage files: we explicitly provide files.