### PR TITLE
update version in prep for v0.2.2

### DIFF
--- a/pkg/plugins/hybrid/v1alpha/scaffolds/init.go
+++ b/pkg/plugins/hybrid/v1alpha/scaffolds/init.go
@@ -41,10 +41,10 @@ const (
 	imageName = "controller:latest"
 
 	// TODO: This is a placeholder for now. This would probably be the operator-sdk version
-	hybridOperatorVersion = "0.2.1"
+	hybridOperatorVersion = "0.2.2"
 
 	// helmPluginVersion is the operator-framework/helm-operator-plugin version to be used in the project
-	helmPluginVersion = "v0.2.1"
+	helmPluginVersion = "v0.2.2"
 )
 
 var _ plugins.Scaffolder = &initScaffolder{}


### PR DESCRIPTION
- release prep pr
- pr after this is released to fix the scafolding since that does a `go get` and errors.

```
ERRO[0003] error creating the project: /helm-operator-plugins/bin/helm-operator-plugins init --plugins hybrid/v1-alpha --repo github.com/example/memcached-operator failed with error: (exit status 1) time="2024-07-17T21:59:54Z" level=info msg="Writing kustomize manifests for you to edit..."
Writing scaffolds for you to edit...
time="2024-07-17T21:59:54Z" level=info msg="Get helm-operator-plugins:\n$ go get github.com/operator-framework/helm-operator-plugins@v0.2.2"
go: github.com/operator-framework/helm-operator-plugins@v0.2.2: invalid version: unknown revision v0.2.2
Error: failed to initialize project: unable to scaffold with "hybrid.helm.sdk.operatorframework.io/v1-alpha": exit status 1
```