### PR TITLE
Bring go.mod to lowest 1.22 z-stream compatible with the code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/operator-framework/helm-operator-plugins
 
-go 1.22.5
+go 1.22.1
 
 require (
 	github.com/go-logr/logr v1.4.2


### PR DESCRIPTION
Downstream users may not be using latest z-streams of go, so this brings it down to the lowest z-stream allowable by the code.