### PR TITLE
pkg/client: add Config method to ActionClient

### DIFF
--- a/pkg/client/actionclient.go
+++ b/pkg/client/actionclient.go
@@ -58,6 +58,7 @@ type ActionInterface interface {
 	Upgrade(name, namespace string, chrt *chart.Chart, vals map[string]interface{}, opts ...UpgradeOption) (*release.Release, error)
 	Uninstall(name string, opts ...UninstallOption) (*release.UninstallReleaseResponse, error)
 	Reconcile(rel *release.Release) error
+	Config() *action.Configuration
 }
 
 type GetOption func(*action.Get) error
@@ -211,6 +212,11 @@ type actionClient struct {
 }
 
 var _ ActionInterface = &actionClient{}
+
+// Config returns action.Configuration that this actionClient uses.
+func (c *actionClient) Config() *action.Configuration {
+	return c.conf
+}
 
 func (c *actionClient) Get(name string, opts ...GetOption) (*release.Release, error) {
 	get := action.NewGet(c.conf)

--- a/pkg/client/actionclient_test.go
+++ b/pkg/client/actionclient_test.go
@@ -454,6 +454,12 @@ var _ = Describe("ActionClient", func() {
 					Expect(resp).To(BeNil())
 				})
 			})
+			var _ = Describe("Config", func() {
+				It("should succeed", func() {
+					config := ac.Config()
+					Expect(config).NotTo(BeNil())
+				})
+			})
 		})
 
 		When("release is installed", func() {
@@ -672,6 +678,12 @@ var _ = Describe("ActionClient", func() {
 						Expect(err).ToNot(HaveOccurred())
 					})
 					verifyRelease(cl, obj, installedRelease)
+				})
+			})
+			var _ = Describe("Config", func() {
+				It("should succeed", func() {
+					config := ac.Config()
+					Expect(config).NotTo(BeNil())
 				})
 			})
 		})


### PR DESCRIPTION
This PR exposes `action.Configuration` of a specific `actionClient` instance via new `Config` method. 

General motivation behind it is for the users to have an 'escape hatch' access to the underlying dependency objects that `action.Configuration` holds, which include for example:
- release records store
- registry client
- Kubernetes API client

More specific motivation comes from a scenario where an access to the underlying release store instance is needed in order to gracefully handle pending helm releases which were previously interrupted.

For additional context on this, see:
https://github.com/operator-framework/operator-controller/pull/1776
and more specifically this thread: https://github.com/operator-framework/operator-controller/pull/1776#discussion_r1958491722

For additional context on the helm interruption issue, see:
https://github.com/helm/helm/issues/5595 and https://github.com/helm/helm/issues/7476

prerequisite and part of OCPBUGS-49729

cc @joelanford 