### PR TITLE
ROX-28223: Pause-reconcile handler

### DIFF
--- a/pkg/reconciler/internal/conditions/conditions.go
+++ b/pkg/reconciler/internal/conditions/conditions.go
@@ -29,10 +29,12 @@ const (
 	TypeDeployed       = "Deployed"
 	TypeReleaseFailed  = "ReleaseFailed"
 	TypeIrreconcilable = "Irreconcilable"
+	TypePaused         = "Paused"
 
-	ReasonInstallSuccessful   = status.ConditionReason("InstallSuccessful")
-	ReasonUpgradeSuccessful   = status.ConditionReason("UpgradeSuccessful")
-	ReasonUninstallSuccessful = status.ConditionReason("UninstallSuccessful")
+	ReasonInstallSuccessful            = status.ConditionReason("InstallSuccessful")
+	ReasonUpgradeSuccessful            = status.ConditionReason("UpgradeSuccessful")
+	ReasonUninstallSuccessful          = status.ConditionReason("UninstallSuccessful")
+	ReasonPauseReconcileAnnotationTrue = status.ConditionReason("PauseReconcileAnnotationTrue")
 
 	ReasonErrorGettingClient       = status.ConditionReason("ErrorGettingClient")
 	ReasonErrorGettingValues       = status.ConditionReason("ErrorGettingValues")
@@ -57,6 +59,10 @@ func ReleaseFailed(stat corev1.ConditionStatus, reason status.ConditionReason, m
 
 func Irreconcilable(stat corev1.ConditionStatus, reason status.ConditionReason, message interface{}) status.Condition {
 	return newCondition(TypeIrreconcilable, stat, reason, message)
+}
+
+func Paused(stat corev1.ConditionStatus, reason status.ConditionReason, message interface{}) status.Condition {
+	return newCondition(TypePaused, stat, reason, message)
 }
 
 func newCondition(t status.ConditionType, s corev1.ConditionStatus, r status.ConditionReason, m interface{}) status.Condition {

--- a/pkg/reconciler/internal/updater/updater.go
+++ b/pkg/reconciler/internal/updater/updater.go
@@ -146,6 +146,12 @@ func EnsureConditionUnknown(t status.ConditionType) UpdateStatusFunc {
 	}
 }
 
+func EnsureConditionAbsent(t status.ConditionType) UpdateStatusFunc {
+	return func(status *helmAppStatus) bool {
+		return status.Conditions.RemoveCondition(t)
+	}
+}
+
 func EnsureDeployedRelease(rel *release.Release) UpdateStatusFunc {
 	return func(status *helmAppStatus) bool {
 		newRel := helmAppReleaseFor(rel)

--- a/pkg/reconciler/internal/updater/updater.go
+++ b/pkg/reconciler/internal/updater/updater.go
@@ -146,12 +146,6 @@ func EnsureConditionUnknown(t status.ConditionType) UpdateStatusFunc {
 	}
 }
 
-func EnsureConditionAbsent(t status.ConditionType) UpdateStatusFunc {
-	return func(status *helmAppStatus) bool {
-		return status.Conditions.RemoveCondition(t)
-	}
-}
-
 func EnsureDeployedRelease(rel *release.Release) UpdateStatusFunc {
 	return func(status *helmAppStatus) bool {
 		newRel := helmAppReleaseFor(rel)

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -458,7 +458,7 @@ func WithPauseReconcileHandler(handler PauseReconcileHandlerFunc) Option {
 // PauseReconcileIfAnnotationTrue returns a PauseReconcileHandlerFunc that pauses reconciliation if the given
 // annotation is present and set to "true"
 func PauseReconcileIfAnnotationTrue(annotationName string) PauseReconcileHandlerFunc {
-	return func(ctx context.Context, obj *unstructured.Unstructured) (bool, error) {
+	return func(_ context.Context, obj *unstructured.Unstructured) (bool, error) {
 		if v, ok := obj.GetAnnotations()[annotationName]; ok && v == "true" {
 			return true, nil
 		}

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -621,13 +621,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 		}
 	}
 
-	u.UpdateStatus(
-		// TODO(ROX-12637): change to updater.EnsureCondition(conditions.Paused(corev1.ConditionFalse, "", "")))
-		// once stackrox operator with pause support is released.
-		// At that time also add `Paused` to the list of conditions expected in stackrox operator e2e tests.
-		// Otherwise, the number of conditions in the `status.conditions` list will vary depending on the version
-		// of used operator, which is cumbersome due to https://github.com/kudobuilder/kuttl/issues/76
-		updater.EnsureConditionAbsent(conditions.TypePaused))
+	u.UpdateStatus(updater.EnsureCondition(conditions.Paused(corev1.ConditionFalse, "", "")))
 
 	actionClient, err := r.actionClientGetter.ActionClientFor(ctx, obj)
 	if err != nil {

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -445,7 +445,7 @@ func WithUninstallAnnotations(as ...annotation.Uninstall) Option {
 type PauseReconcileHandlerFunc func(ctx context.Context, obj *unstructured.Unstructured) (bool, error)
 
 // WithPauseReconcileHandler is an Option that sets a PauseReconcile handler, which is a function that
-// that determines whether reconciliation should be paused for the custom resource watched by this reconciler.
+// determines whether reconciliation should be paused for the custom resource watched by this reconciler.
 //
 // Example usage: WithPauseReconcileHandler(PauseReconcileIfAnnotationTrue("my.domain/pause-reconcile"))
 func WithPauseReconcileHandler(handler PauseReconcileHandlerFunc) Option {
@@ -459,10 +459,8 @@ func WithPauseReconcileHandler(handler PauseReconcileHandlerFunc) Option {
 // annotation is present and set to "true"
 func PauseReconcileIfAnnotationTrue(annotationName string) PauseReconcileHandlerFunc {
 	return func(ctx context.Context, obj *unstructured.Unstructured) (bool, error) {
-		if v, ok := obj.GetAnnotations()[annotationName]; ok {
-			if v == "true" {
-				return true, nil
-			}
+		if v, ok := obj.GetAnnotations()[annotationName]; ok && v == "true" {
+			return true, nil
 		}
 
 		return false, nil

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -621,22 +621,24 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 		}
 	}()
 
-	paused, err := r.pauseHandler(ctx, obj)
-	if err != nil {
-		log.Error(err, "pause reconcile handler failed")
-	}
+	if r.pauseHandler != nil {
+		paused, err := r.pauseHandler(ctx, obj)
+		if err != nil {
+			log.Error(err, "pause reconcile handler failed")
+		}
 
-	if paused {
-		log.Info("Reconcile is paused for this resource.")
-		u.UpdateStatus(
-			updater.EnsureCondition(conditions.Paused(corev1.ConditionTrue, conditions.ReasonPauseReconcileAnnotationTrue, "")),
-			updater.EnsureConditionUnknown(conditions.TypeIrreconcilable),
-			updater.EnsureConditionUnknown(conditions.TypeDeployed),
-			updater.EnsureConditionUnknown(conditions.TypeInitialized),
-			updater.EnsureConditionUnknown(conditions.TypeReleaseFailed),
-			updater.EnsureDeployedRelease(nil),
-		)
-		return ctrl.Result{}, nil
+		if paused {
+			log.Info("Reconcile is paused for this resource.")
+			u.UpdateStatus(
+				updater.EnsureCondition(conditions.Paused(corev1.ConditionTrue, conditions.ReasonPauseReconcileAnnotationTrue, "")),
+				updater.EnsureConditionUnknown(conditions.TypeIrreconcilable),
+				updater.EnsureConditionUnknown(conditions.TypeDeployed),
+				updater.EnsureConditionUnknown(conditions.TypeInitialized),
+				updater.EnsureConditionUnknown(conditions.TypeReleaseFailed),
+				updater.EnsureDeployedRelease(nil),
+			)
+			return ctrl.Result{}, nil
+		}
 	}
 
 	u.UpdateStatus(updater.EnsureCondition(conditions.Paused(corev1.ConditionFalse, "", "")))

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -535,7 +535,6 @@ var _ = Describe("Reconciler", func() {
 						WithInstallAnnotations(annotation.InstallDescription{}),
 						WithUpgradeAnnotations(annotation.UpgradeDescription{}),
 						WithUninstallAnnotations(annotation.UninstallDescription{}),
-						WithPauseReconcileHandler(PauseReconcileIfAnnotationTrue("my.domain/pause-reconcile")),
 						WithOverrideValues(map[string]string{
 							"image.repository": "custom-nginx",
 						}),
@@ -550,7 +549,6 @@ var _ = Describe("Reconciler", func() {
 						WithInstallAnnotations(annotation.InstallDescription{}),
 						WithUpgradeAnnotations(annotation.UpgradeDescription{}),
 						WithUninstallAnnotations(annotation.UninstallDescription{}),
-						WithPauseReconcileHandler(PauseReconcileIfAnnotationTrue("my.domain/pause-reconcile")),
 						WithOverrideValues(map[string]string{
 							"image.repository": "custom-nginx",
 						}),
@@ -1429,6 +1427,11 @@ var _ = Describe("Reconciler", func() {
 						})
 						When("pause-reconcile annotation is present", func() {
 							It("pauses reconciliation", func() {
+								By("adding a pause-reconcile handler to the Reconciler", func() {
+									pauseHandler := WithPauseReconcileHandler(PauseReconcileIfAnnotationTrue("my.domain/pause-reconcile"))
+									pauseHandler(r)
+								})
+
 								By("adding the pause-reconcile annotation to the CR", func() {
 									Expect(mgr.GetClient().Get(ctx, objKey, obj)).To(Succeed())
 									obj.SetAnnotations(map[string]string{"my.domain/pause-reconcile": "true"})

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -1429,7 +1429,7 @@ var _ = Describe("Reconciler", func() {
 							It("pauses reconciliation", func() {
 								By("adding a pause-reconcile handler to the Reconciler", func() {
 									pauseHandler := WithPauseReconcileHandler(PauseReconcileIfAnnotationTrue("my.domain/pause-reconcile"))
-									pauseHandler(r)
+									Expect(pauseHandler(r)).To(Succeed())
 								})
 
 								By("adding the pause-reconcile annotation to the CR", func() {

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -394,13 +394,6 @@ var _ = Describe("Reconciler", func() {
 				}))
 			})
 		})
-		_ = Describe("WithPauseReconcileAnnotation", func() {
-			It("should set the pauseReconcileAnnotation field to the annotation name", func() {
-				a := "my.domain/pause-reconcile"
-				Expect(WithPauseReconcileAnnotation(a)(r)).To(Succeed())
-				Expect(r.pauseReconcileAnnotation).To(Equal(a))
-			})
-		})
 		_ = Describe("WithPreHook", func() {
 			It("should set a reconciler prehook", func() {
 				called := false
@@ -542,7 +535,7 @@ var _ = Describe("Reconciler", func() {
 						WithInstallAnnotations(annotation.InstallDescription{}),
 						WithUpgradeAnnotations(annotation.UpgradeDescription{}),
 						WithUninstallAnnotations(annotation.UninstallDescription{}),
-						WithPauseReconcileAnnotation("my.domain/pause-reconcile"),
+						WithPauseReconcileHandler(PauseReconcileIfAnnotationTrue("my.domain/pause-reconcile")),
 						WithOverrideValues(map[string]string{
 							"image.repository": "custom-nginx",
 						}),
@@ -557,7 +550,7 @@ var _ = Describe("Reconciler", func() {
 						WithInstallAnnotations(annotation.InstallDescription{}),
 						WithUpgradeAnnotations(annotation.UpgradeDescription{}),
 						WithUninstallAnnotations(annotation.UninstallDescription{}),
-						WithPauseReconcileAnnotation("my.domain/pause-reconcile"),
+						WithPauseReconcileHandler(PauseReconcileIfAnnotationTrue("my.domain/pause-reconcile")),
 						WithOverrideValues(map[string]string{
 							"image.repository": "custom-nginx",
 						}),


### PR DESCRIPTION
This PR upstreams a feature from the https://github.com/stackrox/helm-operator fork used by ACS (Advanced Cluster Security)

Source commit: https://github.com/stackrox/helm-operator/commit/30a1ac3212ce7b8733cce1e7e31ea18e138997ab
Original PR: https://github.com/stackrox/helm-operator/pull/29

The PR implements support for a "pause reconcile" handler, which determines if the reconcile should be paused for a given custom resource. Also provided is an implementation for such a handler, that allows pausing reconciliation via a custom annotation that must be added to the CR. If this annotation is set to `true` then the operator does not reconcile the CR.