### PR TITLE
fix: skip reconciliation when label selector does not match

### DIFF
--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -41,6 +41,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -569,6 +570,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 	}
 	if err != nil {
 		return ctrl.Result{}, err
+	}
+
+	if r.selectorPredicate != nil && !r.selectorPredicate.Generic(event.GenericEvent{Object: obj}) {
+		log.V(1).Info("Label selector does not match, skipping reconcile")
+		return ctrl.Result{}, nil
 	}
 
 	// The finalizer must be present on the CR before we can do anything. Otherwise, if the reconciliation fails,


### PR DESCRIPTION
- This change was originally developed in https://github.com/stackrox/helm-operator/pull/42
 
### Issue
- Assume there is CR with label `foo=bar`. 
- a reconciler with label selector `foo=bar` processes the CR as expected
- another reconciler, with label selector `foo=another`, **also** reconciles `foo=bar` CR. This is not expected.

### Root cause
There is [controller.Watch](https://github.com/stackrox/helm-operator/blob/main/pkg/reconciler/reconciler.go#L1161-L1164) set for `Secret` kind. This watch has event handler. The Event handler only filters events by `GroupVersionKind` of the CR so label selector is ignored

### Fix
Check for the matching label selector before performing reconcile. Skip reconcile if label is not matching
