### PR TITLE
Pass label selector predicate to the Secret Watch and handler

### DIFF
--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -1505,7 +1505,7 @@ var _ = Describe("Reconciler", func() {
 									Expect(mgr.GetClient().Update(ctx, obj)).To(Succeed())
 								})
 
-								By("reconciling skiped and no actions for the release", func() {
+								By("reconciling skipped and no actions for the release", func() {
 									res, err := r.Reconcile(ctx, req)
 									Expect(res).To(Equal(reconcile.Result{}))
 									Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
### What

Updated the `setupWatches` method to pass `predicate` if `labelSelector` is set to the reconciler.

### Why

If run two reconcilers with the same GVK but different labelSelectors then **both** reconcilers reconcile each other RCs ignoring configured LabelSelectors. This could be considered as not expected behavior if running two or more reconcilers with the same GVK but different labelSelectors is covered scenario. This PR fixes this issue.

Example logs of two reconcilers with the same GVK but different label selector.
There is only one CR with label `app=nginx`. 
**Reconciler1** has `app=nginx` label selector
**Reconciler2** has `app=foo` label selector


**Reconciler1**:
```

2025-03-27T02:58:33+01:00       INFO    controllers.Helm        Watching resource       {"group": "demo.example.com", "version": "v1alpha1", "kind": "Nginx"}
2025-03-27T02:58:33+01:00       INFO    setup   starting manager with label selector    {"selector": "app=nginx"}
2025-03-27T02:58:33+01:00       INFO    Starting EventSource    {"controller": "nginx-controller", "source": "kind source: *unstructured.Unstructured"}
2025-03-27T02:58:33+01:00       INFO    Starting EventSource    {"controller": "nginx-controller", "source": "kind source: *v1.Secret"}
2025-03-27T02:58:33+01:00       INFO    Starting Controller     {"controller": "nginx-controller"}
2025-03-27T02:58:33+01:00       INFO    Starting workers        {"controller": "nginx-controller", "worker count": 1}
2025-03-27T02:58:33+01:00       DEBUG   controllers.Helm        Reconciliation triggered        {"nginx": {"name":"nginx-sample","namespace":"default"}}
...
```

**Reconciler2**:
```
2025-03-27T03:00:39+01:00       INFO    controllers.Helm        Watching resource       {"group": "demo.example.com", "version": "v1alpha1", "kind": "Nginx"}
2025-03-27T03:00:39+01:00       INFO    setup   starting manager with label selector    {"selector": "app=foo"}
2025-03-27T03:00:39+01:00       INFO    Starting EventSource    {"controller": "nginx-controller", "source": "kind source: *unstructured.Unstructured"}
2025-03-27T03:00:39+01:00       INFO    Starting EventSource    {"controller": "nginx-controller", "source": "kind source: *v1.Secret"}
2025-03-27T03:00:39+01:00       INFO    Starting Controller     {"controller": "nginx-controller"}
2025-03-27T03:00:39+01:00       INFO    Starting workers        {"controller": "nginx-controller", "worker count": 1}
2025-03-27T03:00:39+01:00       DEBUG   controllers.Helm        Reconciliation triggered        {"nginx": {"name":"nginx-sample","namespace":"default"}}
```

### Manual testing

This [small setup](https://github.com/kurlov/helm-operator-plugins-test-locally) was used for running locally two reconcilers: 

Running locally with the fix shows that only one reconciler reconcile the CR and another 

**Reconciler1**:
```
2025-03-27T03:18:53+01:00       INFO    controllers.Helm        Watching resource       {"group": "demo.example.com", "version": "v1alpha1", "kind": "Nginx"}
2025-03-27T03:18:53+01:00       INFO    setup   starting manager with label selector    {"selector": "app=nginx"}
2025-03-27T03:18:53+01:00       INFO    Starting EventSource    {"controller": "nginx-controller", "source": "kind source: *unstructured.Unstructured"}
2025-03-27T03:18:53+01:00       INFO    Starting EventSource    {"controller": "nginx-controller", "source": "kind source: *v1.Secret"}
2025-03-27T03:18:53+01:00       INFO    Starting Controller     {"controller": "nginx-controller"}
2025-03-27T03:18:53+01:00       INFO    Starting workers        {"controller": "nginx-controller", "worker count": 1}
2025-03-27T03:18:53+01:00       DEBUG   controllers.Helm        Reconciliation triggered        {"nginx": {"name":"nginx-sample","namespace":"default"}}
```

**Reconciler2**:
```
2025-03-27T03:18:37+01:00       INFO    controllers.Helm        Watching resource       {"group": "demo.example.com", "version": "v1alpha1", "kind": "Nginx"}
2025-03-27T03:18:37+01:00       INFO    setup   starting manager with label selector    {"selector": "app=foo"}
2025-03-27T03:18:37+01:00       INFO    Starting EventSource    {"controller": "nginx-controller", "source": "kind source: *unstructured.Unstructured"}
2025-03-27T03:18:37+01:00       INFO    Starting EventSource    {"controller": "nginx-controller", "source": "kind source: *v1.Secret"}
2025-03-27T03:18:37+01:00       INFO    Starting Controller     {"controller": "nginx-controller"}
2025-03-27T03:18:37+01:00       INFO    Starting workers        {"controller": "nginx-controller", "worker count": 1}
```