### PR TITLE
fix: labelSelector emptiness check

### DIFF
--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -1025,7 +1025,7 @@ func (r *Reconciler) setupWatches(mgr ctrl.Manager, c controller.Controller) err
 
 	var preds []predicate.Predicate
 
-	if r.labelSelector.MatchLabels != nil {
+	if r.labelSelector.Size() > 0 {
 		selectorPredicate, err := predicate.LabelSelectorPredicate(r.labelSelector)
 		if err != nil {
 			return err


### PR DESCRIPTION
Unfortunately, [this test](https://github.com/operator-framework/helm-operator-plugins/blob/b4b9a06ba6576e46b6053bb098f5dbd851ebbd46/pkg/reconciler/reconciler_test.go#L1495) is mostly useless, both for testing this fix and in general :sad_meow: because we set the selector predicate on the watch has no influence on the execution of Reconcile().
In order to test whether WithSelector has any effect, we'd have to invoke the controller manager, because that is where the filtering happens.
Probably something like [this test](https://github.com/operator-framework/helm-operator-plugins/blob/b4b9a06ba6576e46b6053bb098f5dbd851ebbd46/pkg/manager/namespace_test.go#L72) does.

However this is a more involved undertaking than I have time for right now, so just sending this fix alone at this time.

cc @kurlov 

Fixes: #458 