### PR TITLE
fix gpg release workflow by removing vestigial fingerprint var

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,6 @@ jobs:
         make release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
 
   docker:
     # TODO(fabianvf): skip pushing images for now, reenable once we're


### PR DESCRIPTION
Vestigial GPG_FINGERPRINT variable in the deployment workflow, which isn't set because there is no import_gpg workflow, so the field evaluation fails. 
